### PR TITLE
[move] restore files from Diem commit 782b

### DIFF
--- a/framework/libra-framework/sources/ol_sources/libra_coin.move
+++ b/framework/libra-framework/sources/ol_sources/libra_coin.move
@@ -1,0 +1,109 @@
+address 0x0:
+
+module LibraCoin {
+    use 0x0.Transaction;
+
+    // A resource representing the Libra coin
+    // The value of the coin. May be zero
+    resource struct T { value: u64 }
+
+    // A singleton resource that grants access to `LibraCoin.mint`. Only the Association has one.
+    resource struct MintCapability {}
+
+    // The sum of the values of all LibraCoin.T resources in the system
+    resource struct MarketCap { total_value: u64 }
+
+    // Return a reference to the MintCapability published under the sender's account. Fails if the
+    // sender does not have a MintCapability.
+    // Since only the Association account has a mint capability, this will only succeed if it is
+    // invoked by a transaction sent by that account.
+    public mint_with_default_capability(amount: u64): T acquires MintCapability, MarketCap {
+        mint(amount, borrow_global<MintCapability>(Transaction.sender()))
+    }
+
+    // Mint a new LibraCoin.T worth `value`. The caller must have a reference to a MintCapability.
+    // Only the Association account can acquire such a reference, and it can do so only via
+    // `borrow_sender_mint_capability`
+    public mint(value: u64, capability: &MintCapability): T acquires MarketCap {
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        // * 1000000 because the unit is microlibra
+        Transaction.assert(value <= 1000000000 * 1000000, 11);
+
+        // update market cap resource to reflect minting
+        let market_cap = borrow_global_mut<MarketCap>(0xA550C18);
+        market_cap.total_value = market_cap.total_value + value;
+
+        T { value }
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public initialize() {
+        // Only callable by the Association address
+        Transaction.assert(Transaction.sender() == 0xA550C18, 1);
+
+        move_to_sender(MintCapability{});
+        move_to_sender(MarketCap { total_value: 0 });
+    }
+
+    // Return the total value of all Libra in the system
+    public market_cap(): u64 acquires MarketCap {
+        borrow_global<MarketCap>(0xA550C18).total_value
+    }
+
+    // Create a new LibraCoin.T with a value of 0
+    public zero(): T {
+        T { value: 0 }
+    }
+
+    // Public accessor for the value of a coin
+    public value(coin: &T): u64 {
+        coin.value
+    }
+
+    // Splits the given coin into two and returns them both
+    // It leverages `Self.withdraw` for any verifications of the values
+    public split(coin: T, amount: u64): (T, T) {
+        let other = coin.withdraw(amount);
+        (coin, other)
+    }
+
+    // "Divides" the given coin into two, where original coin is modified in place
+    // The original coin will have value = original value - `amount`
+    // The new coin will have a value = `amount`
+    // Fails if the coins value is less than `amount`
+    public withdraw(coin: &mut T, amount: u64): T {
+        // Check that `amount` is less than the coin's value
+        Transaction.assert(coin.value >= amount, 10);
+        // Split the coin
+        coin.value = coin.value - amount;
+        T { value: amount }
+    }
+
+    // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public join(coin1: T, coin2: T): T  {
+        coin1.deposit(coin2);
+        coin1
+    }
+
+    // "Merges" the two coins
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public deposit(coin: &mut T, check: T) {
+        let T { value } = check;
+        coin.value = coin.value + value
+    }
+
+    // Destroy a coin
+    // Fails if the value is non-zero
+    // The amount of LibraCoin.T in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of LibraCoin.T
+    public destroy_zero(coin: Self.T) {
+        let T { value } = coin;
+        Transaction.assert(value == 0, 11)
+    }
+
+}

--- a/framework/libra-framework/sources/ol_sources/libra_coin.move
+++ b/framework/libra-framework/sources/ol_sources/libra_coin.move
@@ -16,21 +16,21 @@ module 0x0::LibraCoin {
     // A singleton that grants access to `LibraCoin.mint`. Only the Association has one.
     struct MintCapability {}
 
-    // The sum of the values of all LibraCoin.T resources in the system
+    // The sum of the values of all LibraCoin resources in the system
     struct MarketCap { total_value: u64 }
 
     // Return a reference to the MintCapability published under the sender's account. Fails if the
     // sender does not have a MintCapability.
     // Since only the Association account has a mint capability, this will only succeed if it is
     // invoked by a transaction sent by that account.
-    public mint_with_default_capability(amount: u64): T acquires MintCapability, MarketCap {
+    public fun mint_with_default_capability(amount: u64): LibraCoin acquires MintCapability, MarketCap {
         mint(amount, borrow_global<MintCapability>(Transaction.sender()))
     }
 
-    // Mint a new LibraCoin.T worth `value`. The caller must have a reference to a MintCapability.
+    // Mint a new LibraCoin worth `value`. The caller must have a reference to a MintCapability.
     // Only the Association account can acquire such a reference, and it can do so only via
     // `borrow_sender_mint_capability`
-    public mint(value: u64, capability: &MintCapability): T acquires MarketCap {
+    public fun mint(value: u64, capability: &MintCapability): LibraCoin acquires MarketCap {
         // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
         // this is to prevent the market cap's total value from hitting u64_max due to excessive
         // minting. This will not be a problem in the production Libra system because coins will
@@ -42,12 +42,12 @@ module 0x0::LibraCoin {
         let market_cap = borrow_global_mut<MarketCap>(0xA550C18);
         market_cap.total_value = market_cap.total_value + value;
 
-        T { value }
+        LibraCoin { value }
     }
 
     // This can only be invoked by the Association address, and only a single time.
     // Currently, it is invoked in the genesis transaction
-    public initialize() {
+    public fun initialize() {
         // Only callable by the Association address
         Transaction.assert(Transaction.sender() == 0xA550C18, 1);
 
@@ -56,24 +56,24 @@ module 0x0::LibraCoin {
     }
 
     // Return the total value of all Libra in the system
-    public market_cap(): u64 acquires MarketCap {
+    public fun market_cap(): u64 acquires MarketCap {
         borrow_global<MarketCap>(0xA550C18).total_value
     }
 
-    // Create a new LibraCoin.T with a value of 0
-    public zero(): T {
-        T { value: 0 }
+    // Create a new LibraCoin with a value of 0
+    public fun zero(): LibraCoin {
+        LibraCoin { value: 0 }
     }
 
     // Public accessor for the value of a coin
-    public value(coin: &T): u64 {
-        coin.value
+    public fun value(coin: &LibraCoin): u64 {
+        value(coin)
     }
 
     // Splits the given coin into two and returns them both
     // It leverages `Self.withdraw` for any verifications of the values
-    public split(coin: T, amount: u64): (T, T) {
-        let other = coin.withdraw(amount);
+    public fun split(coin: LibraCoin, amount: u64): (LibraCoin, LibraCoin) {
+        let other = withdraw(coin, amount);
         (coin, other)
     }
 
@@ -81,34 +81,34 @@ module 0x0::LibraCoin {
     // The original coin will have value = original value - `amount`
     // The new coin will have a value = `amount`
     // Fails if the coins value is less than `amount`
-    public withdraw(coin: &mut T, amount: u64): T {
+    public fun withdraw(coin: &mut LibraCoin, amount: u64): LibraCoin {
         // Check that `amount` is less than the coin's value
         Transaction.assert(coin.value >= amount, 10);
         // Split the coin
-        coin.value = coin.value - amount;
-        T { value: amount }
+        coin.value = value(coin) - amount;
+        LibraCoin { value: amount }
     }
 
     // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
-    public join(coin1: T, coin2: T): T  {
-        coin1.deposit(coin2);
+    public fun join(coin1: &mut LibraCoin, coin2: LibraCoin): LibraCoin  {
+        deposit(coin1, coin2);
         coin1
     }
 
     // "Merges" the two coins
     // The coin passed in by reference will have a value equal to the sum of the two coins
     // The `check` coin is consumed in the process
-    public deposit(coin: &mut T, check: T) {
-        let T { value } = check;
-        coin.value = coin.value + value
+    public fun deposit(coin: &mut LibraCoin, check: LibraCoin) {
+        let LibraCoin { value } = check;
+        coin.value = value(coin) + value
     }
 
     // Destroy a coin
     // Fails if the value is non-zero
-    // The amount of LibraCoin.T in the system is a tightly controlled property,
-    // so you cannot "burn" any non-zero amount of LibraCoin.T
-    public destroy_zero(coin: Self.T) {
-        let T { value } = coin;
+    // The amount of LibraCoin in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of LibraCoin
+    public fun destroy_zero(coin: LibraCoin) {
+        let LibraCoin { value } = coin;
         Transaction.assert(value == 0, 11)
     }
 

--- a/framework/libra-framework/sources/ol_sources/libra_coin.move
+++ b/framework/libra-framework/sources/ol_sources/libra_coin.move
@@ -1,3 +1,11 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0
+// Original source:
+// https://github.com/diem/diem/blob/782b31cb08eeb717ea2b6f3edbf616b13fd4cae8/language/move-lang/stdlib/modules/libra_coin.move
+// Original Commit:
+// https://github.com/diem/diem/commit/782b31cb08eeb717ea2b6f3edbf616b13fd4cae8
+
 address 0x0:
 
 module LibraCoin {

--- a/framework/libra-framework/sources/ol_sources/libra_coin.move
+++ b/framework/libra-framework/sources/ol_sources/libra_coin.move
@@ -6,20 +6,18 @@
 // Original Commit:
 // https://github.com/diem/diem/commit/782b31cb08eeb717ea2b6f3edbf616b13fd4cae8
 
-address 0x0:
+module 0x0::LibraCoin {
+    use 0x0::Transaction;
 
-module LibraCoin {
-    use 0x0.Transaction;
-
-    // A resource representing the Libra coin
+    // A representing the Libra coin
     // The value of the coin. May be zero
-    resource struct T { value: u64 }
+    struct LibraCoin { value: u64 }
 
-    // A singleton resource that grants access to `LibraCoin.mint`. Only the Association has one.
-    resource struct MintCapability {}
+    // A singleton that grants access to `LibraCoin.mint`. Only the Association has one.
+    struct MintCapability {}
 
     // The sum of the values of all LibraCoin.T resources in the system
-    resource struct MarketCap { total_value: u64 }
+    struct MarketCap { total_value: u64 }
 
     // Return a reference to the MintCapability published under the sender's account. Fails if the
     // sender does not have a MintCapability.
@@ -40,7 +38,7 @@ module LibraCoin {
         // * 1000000 because the unit is microlibra
         Transaction.assert(value <= 1000000000 * 1000000, 11);
 
-        // update market cap resource to reflect minting
+        // update market cap to reflect minting
         let market_cap = borrow_global_mut<MarketCap>(0xA550C18);
         market_cap.total_value = market_cap.total_value + value;
 
@@ -53,8 +51,8 @@ module LibraCoin {
         // Only callable by the Association address
         Transaction.assert(Transaction.sender() == 0xA550C18, 1);
 
-        move_to_sender(MintCapability{});
-        move_to_sender(MarketCap { total_value: 0 });
+        move_to(MintCapability{});
+        move_to(MarketCap { total_value: 0 });
     }
 
     // Return the total value of all Libra in the system


### PR DESCRIPTION
- Restore the (simpler) coin code from the original Move framework commit.
- Needed to be updated for new language features since publication (minor changes, no changes to APIs).
- Add copyright and license notices