### PR TITLE
[CI] Update workflows to utilize our self hosted runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   rust-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url
     - name: Setup tmate session

--- a/.github/workflows/cleanliness.yaml
+++ b/.github/workflows/cleanliness.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted 
     steps:
       - uses: actions/checkout@v3
       - name: setup env

--- a/.github/workflows/move.yaml
+++ b/.github/workflows/move.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   functional-tests:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
     # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url
     # - name: Setup tmate session


### PR DESCRIPTION
NOTE: As a future feature when we have more clarity about our self hosted runner infrastructure we can add logic to revert to a backup github runner in case of failure