### PR TITLE
[CI] github actions compile cache fixes

### DIFF
--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -4,21 +4,21 @@ runs:
   using: composite
   steps:
 
-    # - name: free disk space
-    #   uses: jlumbroso/free-disk-space@main
-    #   with:
-    #     # this might remove tools that are actually needed,
-    #     # if set to "true" but frees about 6 GB
-    #     tool-cache: false
+    - name: free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        # this might remove tools that are actually needed,
+        # if set to "true" but frees about 6 GB
+        tool-cache: false
 
-    #     # all of these default to true, but feel free to set to
-    #     # "false" if necessary for your workflow
-    #     android: true
-    #     dotnet: true
-    #     haskell: true
-    #     large-packages: false
-    #     docker-images: true
-    #     swap-storage: true
+        # all of these default to true, but feel free to set to
+        # "false" if necessary for your workflow
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
 
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:
@@ -35,32 +35,23 @@ runs:
       shell: bash
       run: rustup component add rustfmt clippy
 
-    # - name: install sccache
-    #   uses: baptiste0928/cargo-install@v2
-    #   with:
-    #     crate: sccache
+    - name: enable sccache
+      uses: 0o-de-lally/sccache-action@local
 
-    # - name: download sccache bin
-    #   shell: bash
-    #   run: >
-    #     wget https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz &&
-    #     tar -xvf sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz &&
-    #     cp sccache-v0.5.4-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache &&
-    #     chmod 744 /usr/local/bin/sccache
+    - name: also rust cache
+      uses: Swatinem/rust-cache@v2.7.0
+      with:
+        shared-key: "libra"
+        cache-on-failure: "true"
 
-    # - name: checkout sources
-    #   uses: actions/checkout@v3
-    #   with:
-    #     # git-restore-mtime-bare uses the ref log to find the correct timestamp
-    #     # for each file. This requires a full git history. The default value (1)
-    #     # creates a shallow checkout.
-    #     fetch-depth: 0
+    - name: export diem-node DIEM_FORGE_NODE_BIN_PATH
+      shell: bash
+      run: echo "DIEM_FORGE_NODE_BIN_PATH=${{github.workspace}}/diem-node" >> $GITHUB_ENV
 
-    # - name: cache rust
-    #   uses: Swatinem/rust-cache@v2
-    #   with:
-    #     shared-key: "libra" # to share across CI builds, so it is not job-id specific
-    #     cache-on-failure: true
-
-    # - name: cargo mtime reset
-    #   uses: chetan/git-restore-mtime-action@v2
+    - name: install diem-node (for smoke tests)
+      shell: bash
+      run: >
+        wget -O $DIEM_FORGE_NODE_BIN_PATH https://github.com/0LNetworkCommunity/diem/releases/latest/download/diem-node &&
+        sudo chmod 755 $DIEM_FORGE_NODE_BIN_PATH &&
+        echo $DIEM_FORGE_NODE_BIN_PATH &&
+        ls -l $DIEM_FORGE_NODE_BIN_PATH

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,90 +3,118 @@ name: rust ci
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
-      - 'ci*'
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
     branches:
-      - 'main'
-      - 'ci'
+      - "release**"
+      - "main"
+      - "ci"
   pull_request:
     types:
       - opened
       - synchronize
     branches:
-      - 'release**'
-      - 'main'
+      - "release**"
+      - "main"
 env:
   DIEM_FORGE_NODE_BIN_PATH: ${{github.workspace}}/diem-node
   LIBRA_CI: 1
   MODE_0L: "TESTNET"
-  # SCCACHE_BUCKET: ubuntu-libra
-  # SCCACHE_ENDPOINT: https://afcdb03dd0764818ac9aec7fe0c0b8b5.r2.cloudflarestorage.com/ubuntu-libra
-  # AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-  # AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  # SCCACHE_REGION: auto
 
 jobs:
-  rust-tests:
-    runs-on: self-hosted
+  build-framework:
+    runs-on: ubuntu-latest
     steps:
-    # # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
-    #   with:
-    #     detached: true
-    #   # timeout-minutes: 15
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      - name: build framework
+        working-directory: ./framework
+        run: cargo r release
 
-    - uses: actions/checkout@v3
-    - name: setup env
-      uses: ./.github/actions/build_env
+  types:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
 
-    - name: install diem-node (for smoke tests)
-      run: >
-        wget -O $DIEM_FORGE_NODE_BIN_PATH https://github.com/0LNetworkCommunity/diem/releases/latest/download/diem-node &&
-        sudo chmod 755 $DIEM_FORGE_NODE_BIN_PATH &&
-        echo $DIEM_FORGE_NODE_BIN_PATH &&
-        ls -l $DIEM_FORGE_NODE_BIN_PATH
+      # fail fast if types doesnt compile, everything else will fail.
+      - name: types
+        working-directory: ./types
+        run: cargo test --no-fail-fast
+  wallet:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      - name: wallet
+        if: always()
+        working-directory: ./tools/wallet
+        run: cargo test --no-fail-fast
 
-    # - name: set sccache
-    #   # don't do this before test because rust tools may not build inluding sccache itself.
-    #   # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-    #   shell: bash
-    #   run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+  smoke:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      # Check test suite meta tests
+      - name: smoke-tests # NOTE: needs working DIEM_FORGE_NODE_BIN_PATH
+        if: always()
+        working-directory: ./smoke-tests
+        run: cargo test --no-fail-fast
 
-    # fail fast if types doesnt compile, everything else will fail.
-    - name: types
-      working-directory: ./types
-      run: cargo test --no-fail-fast --target x86_64-unknown-linux-gnu
+  query:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
 
-    - name: wallet
-      if: always()
-      working-directory: ./tools/wallet
-      run: cargo test --no-fail-fast
+      # Tools tests (some use smoke-tests)
+      - name: query
+        if: always()
+        working-directory: ./tools/query
+        run: cargo test --no-fail-fast
 
-    # Check test suite meta tests
-    - name: smoke-tests # NOTE: needs working DIEM_FORGE_NODE_BIN_PATH
-      if: always()
-      working-directory: ./smoke-tests
-      run: cargo test --no-fail-fast
+  genesis:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      - name: genesis
+        if: always()
+        working-directory: ./tools/genesis
+        run: cargo test --no-fail-fast
 
-    # Tools tests (some use smoke-tests)
-    - name: query
-      if: always()
-      working-directory: ./tools/query
-      run: cargo test --no-fail-fast
+  tower:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      - name: tower
+        if: always()
+        working-directory: ./tools/tower
+        run: cargo test --no-fail-fast
 
-    - name: genesis
-      if: always()
-      working-directory: ./tools/genesis
-      run: cargo test --no-fail-fast
-
-    - name: tower
-      if: always()
-      working-directory: ./tools/tower
-      run: cargo test --no-fail-fast
-
-    - name: txs
-      if: always()
-      working-directory: ./tools/txs
-      run: cargo test --no-fail-fast
+  txs:
+    needs: [build-framework]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup env
+        uses: ./.github/actions/build_env
+      - name: txs
+        if: always()
+        working-directory: ./tools/txs
+        run: cargo test --no-fail-fast

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: setup env
         uses: ./.github/actions/build_env
+
       - name: txs
         if: always()
         working-directory: ./tools/txs
-        run: cargo test --no-fail-fast
+        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with the default rust stack size.
+        run: RUST_MIN_STACK=104857600 cargo test --no-fail-fast

--- a/.github/workflows/cleanliness.yaml
+++ b/.github/workflows/cleanliness.yaml
@@ -2,6 +2,9 @@ name: cleanliness
 on:
   push:
     branches: ["*"]
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
   pull_request:
     types:
       - opened
@@ -9,26 +12,19 @@ on:
     branches:
       - 'release**'
       - 'main'
-# env:
-#   SCCACHE_BUCKET: ubuntu-libra
-#   SCCACHE_ENDPOINT: https://afcdb03dd0764818ac9aec7fe0c0b8b5.r2.cloudflarestorage.com/ubuntu-libra
-#   AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-#   AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-#   SCCACHE_REGION: auto
+env:
+  DIEM_FORGE_NODE_BIN_PATH: ${{github.workspace}}/diem-node
+  LIBRA_CI: 1
+  MODE_0L: "TESTNET"
 
 jobs:
   clippy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
 
+      - uses: actions/checkout@v3
       - name: setup env
         uses: ./.github/actions/build_env
-
-      # - name: set sccache
-      #   # don't do this before test because rust tools may not build inluding sccache itself.
-      #   # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-      #   run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: format
         uses: actions-rs/cargo@v1

--- a/.github/workflows/move.yaml
+++ b/.github/workflows/move.yaml
@@ -4,8 +4,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
-      - 'ci*'
+      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
     branches:
       - 'main'
       - 'ci'
@@ -19,7 +18,7 @@ on:
 
 jobs:
   functional-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     # NOTE: for debugging CI this allow shell access to github runner. Will print out tmate.io terminal url
     # - name: Setup tmate session

--- a/.github/workflows/nuke-ci.yaml
+++ b/.github/workflows/nuke-ci.yaml
@@ -1,0 +1,29 @@
+name: nuke the CI
+on:
+  push:
+    tags:
+      - "nuke-ci*"
+jobs:
+  delete_all_runs:
+    name: delete all workflow runs
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 0 #${{ github.event.inputs.days }}
+          keep_minimum_runs: 0 # ${{ github.event.inputs.minimum_runs }}
+          # delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          # delete_workflow_by_state_pattern: disabled_manually
+          # delete_run_by_conclusion_pattern: ${{ github.event.inputs.delete_run_by_conclusion_pattern }}
+          # dry_run: true
+  wipe_caches:
+    name: delete all caches
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: clear caches
+        uses: easimon/wipe-cache@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1812,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1859,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "serde 1.0.171",
  "serde_bytes",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "futures",
  "tokio",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "shadow-rs",
 ]
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anstyle",
  "clap 4.3.23",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-crypto",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "backtrace",
  "diem-logger",
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2215,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2289,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2339,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "clap 4.3.23",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "thiserror",
 ]
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "again",
  "anyhow",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "move-core-types",
 ]
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-proxy",
  "serde 1.0.171",
@@ -2738,17 +2738,17 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2824,12 +2824,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2853,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2879,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-runtimes",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -3026,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "hex",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "chrono",
 ]
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "clap 4.3.23",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "claims",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "diem-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "cfg-if",
  "diem-build-info",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.33",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3340,7 +3340,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3366,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3416,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "pbjson",
  "prost",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "ipnet",
 ]
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3496,7 +3496,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3543,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "tokio",
 ]
@@ -3594,7 +3594,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3632,7 +3632,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3688,7 +3688,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "mirai-annotations",
  "serde 1.0.171",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3819,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3859,7 +3859,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3874,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "diem-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-api",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "diem-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "again",
  "anyhow",
@@ -4011,7 +4011,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "again",
  "anyhow",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -4105,12 +4105,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4215,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4244,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4259,7 +4259,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6395,7 +6395,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6429,12 +6429,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6449,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6475,7 +6475,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "clap 4.3.23",
@@ -6492,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6536,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "difference",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6582,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6624,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "clap 4.3.23",
@@ -6642,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6675,7 +6675,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6694,7 +6694,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "hex",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "hex",
@@ -6740,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6767,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6869,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6910,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "hex",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "once_cell",
  "serde 1.0.171",
@@ -6942,7 +6942,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "clap 4.3.23",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7037,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
@@ -9293,7 +9293,7 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#261f9a9211135d9799984c15206429fb19a9efe7"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#5b1067cb80b8bb3e5d3e3394e915815a03586cac"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Fix github actions caching with dual caches and split tests into multiple parallel jobs. Uses github hosted runners again.

Had to write own caching action for sccache here: https://github.com/0o-de-lally/sccache-action. Bless you my fragile and tender rust compile cache.