### PR TITLE
[move] fix lifetime burn info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,6 +5811,7 @@ dependencies = [
  "diem-crypto",
  "diem-framework",
  "diem-types",
+ "git2 0.16.1",
  "hex",
  "move-command-line-common",
  "move-model",

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -22,6 +22,7 @@ diem-build-info = { workspace = true }
 diem-crypto = { workspace = true }
 diem-framework = { workspace = true }
 diem-types = { workspace = true }
+git2 = { workspace = true }
 hex = { workspace = true }
 move-command-line-common = { workspace = true }
 move-model = { workspace = true }

--- a/framework/libra-framework/sources/modified_source/coin.move
+++ b/framework/libra-framework/sources/modified_source/coin.move
@@ -18,6 +18,7 @@ module diem_framework::coin {
     // use diem_std::debug::print;
 
     friend ol_framework::gas_coin;
+    friend ol_framework::burn;
     friend ol_framework::ol_account;
     friend diem_framework::genesis;
     friend diem_framework::genesis_migration;
@@ -341,7 +342,10 @@ module diem_framework::coin {
 
     // Public functions
     /// Burn `coin` with capability.
-    /// The capability `_cap` should be passed as a reference to `BurnCapability<CoinType>`.
+    /// The capability `_cap` should be passed as a reference to
+    /// `BurnCapability<CoinType>`.
+
+    // 0L: TODO: isn't this deprecated?
     public(friend) fun burn<CoinType>(
         coin: Coin<CoinType>,
         _cap: &BurnCapability<CoinType>,
@@ -358,8 +362,9 @@ module diem_framework::coin {
 
     //////// 0L ////////
     /// user can burn own coin they are holding.
-    /// TODO: evaluate if this should be a `friend` method
-    public fun user_burn<CoinType>(
+    /// must be a Friend function, because the relevant tracking
+    /// happens in Burn.move
+    public(friend) fun user_burn<CoinType>(
         coin: Coin<CoinType>,
     ) acquires CoinInfo { // cannot abort
         if (value(&coin) == 0) {
@@ -380,7 +385,10 @@ module diem_framework::coin {
     /// The capability `burn_cap` should be passed as a reference to `BurnCapability<CoinType>`.
     /// This function shouldn't fail as it's called as part of transaction fee burning.
     ///
-    /// Note: This bypasses CoinStore::frozen -- coins within a frozen CoinStore can be burned.
+    /// Note: This bypasses CoinStore::frozen -- coins within a frozen CoinStore
+    /// can be burned.
+
+    // 0L: is this deprecated?
     public(friend) fun burn_from<CoinType>(
         account_addr: address,
         amount: u64,

--- a/framework/libra-framework/sources/modified_source/diem_governance.move
+++ b/framework/libra-framework/sources/modified_source/diem_governance.move
@@ -45,7 +45,7 @@ module diem_framework::diem_governance {
     const ENOT_DELEGATED_VOTER: u64 = 2;
     /// The specified stake pool does not have long enough remaining lockup to create a proposal or vote
     const EINSUFFICIENT_STAKE_LOCKUP: u64 = 3;
-    /// The specified stake pool has already been used to vote on the same proposal
+    /// The specified address already been used to vote on the same proposal
     const EALREADY_VOTED: u64 = 4;
     /// The specified stake pool must be part of the validator set
     const ENO_VOTING_POWER: u64 = 5;

--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -230,8 +230,10 @@ module diem_framework::epoch_boundary {
 
           // remainder gets burnt according to fee maker preferences
           burn::epoch_burn_fees(root, &mut all_fees);
-          // there might be some dust, that should get burned
-          coin::user_burn(all_fees);
+
+          // coin can finally be destroyed. Up to here we have been extracting from a mutable.
+          // It's possible there might be some dust, that should get burned
+          burn::burn_and_track(all_fees);
         };
 
         compliant_vals

--- a/framework/libra-framework/sources/ol_sources/pledge_accounts.move
+++ b/framework/libra-framework/sources/ol_sources/pledge_accounts.move
@@ -47,6 +47,7 @@
         use ol_framework::gas_coin::LibraCoin as GasCoin;
         use ol_framework::ol_account;
         use ol_framework::epoch_helper;
+        use ol_framework::burn;
         use diem_framework::system_addresses;
         use diem_framework::coin::{Self, Coin};
 
@@ -466,7 +467,7 @@
 
                 if (is_burn && option::is_some(&c)) {
                   let burn_this = option::extract(&mut c);
-                  coin::user_burn(burn_this);
+                  burn::burn_and_track(burn_this);
                   option::destroy_none(c);
                 } else if (option::is_some(&c)) {
                   let refund_coin = option::extract(&mut c);

--- a/framework/libra-framework/sources/ol_sources/proof_of_fee.move
+++ b/framework/libra-framework/sources/ol_sources/proof_of_fee.move
@@ -90,7 +90,7 @@ module ol_framework::proof_of_fee {
   // from supply data.
   public fun genesis_migrate_reward(vm: &signer, nominal_reward: u64) acquires
   ConsensusReward {
-    if (signer::address_of(vm) != @ol_framework) return;
+    system_addresses::assert_ol(vm); // either 0x1 or 0x0
 
     let state = borrow_global_mut<ConsensusReward>(@ol_framework);
     state.nominal_reward = nominal_reward;

--- a/framework/libra-framework/sources/ol_sources/tests/burn.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/burn.test.move
@@ -2,7 +2,7 @@
 #[test_only]
 module ol_framework::test_burn {
   use ol_framework::mock;
-  use ol_framework::gas_coin::{Self, LibraCoin as GasCoin};
+  use ol_framework::gas_coin;
   use ol_framework::ol_account;
   use ol_framework::match_index;
   use ol_framework::burn;
@@ -27,7 +27,7 @@ module ol_framework::test_burn {
 
     let alice_burn = 5;
     let c = ol_account::withdraw(alice, alice_burn);
-    coin::user_burn<GasCoin>(c);
+    burn::burn_and_track(c);
     let supply = gas_coin::supply();
     assert!(supply == (supply_pre - alice_burn), 7357001);
 

--- a/framework/libra-framework/sources/ol_sources/tests/donor_directed.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/donor_directed.test.move
@@ -13,7 +13,7 @@ module ol_framework::test_donor_directed {
   use std::vector;
   use std::signer;
 
-  // use diem_std::debug::print;
+  use diem_std::debug::print;
 
     #[test(root = @ol_framework, alice = @0x1000a)]
     fun dd_init(root: &signer, alice: &signer) {
@@ -377,7 +377,7 @@ module ol_framework::test_donor_directed {
     }
 
     #[test(root = @ol_framework, alice = @0x1000a, dave = @0x1000d, eve = @0x1000e)]
-    fun dd_liquidate_to_community(root: &signer, alice: &signer, dave: &signer, eve: &signer) {
+    fun dd_liquidate_to_match_index(root: &signer, alice: &signer, dave: &signer, eve: &signer) {
       // Scenario:
       // Alice creates a donor directed account where Alice, Bob and Carol, are admins.
       // Dave and Eve make a donation and so are able to have some voting on that account.
@@ -404,7 +404,8 @@ module ol_framework::test_donor_directed {
       assert!(is_donor, 7357002);
 
       // Dave will also be a donor, with half the amount of what Eve sends
-      ol_account::transfer(dave, donor_directed_address, 21);
+      let dave_donation = 21;
+      ol_account::transfer(dave, donor_directed_address, dave_donation);
       let is_donor = donor_directed_governance::check_is_donor(donor_directed_address, signer::address_of(dave));
       assert!(is_donor, 7357003);
 
@@ -423,18 +424,21 @@ module ol_framework::test_donor_directed {
       let list = donor_directed::get_liquidation_queue();
       assert!(vector::length(&list) > 0, 7357005);
 
+      // check the table of refunds
+      // dave and eve should be receiving
       let (addrs, refunds) = donor_directed::get_pro_rata(donor_directed_address);
 
       assert!(*vector::borrow(&addrs, 0) == @0x1000e, 7357006);
       assert!(*vector::borrow(&addrs, 1) == @0x1000d, 7357007);
 
+      // for the first refund,
       let eve_donation_pro_rata = vector::borrow(&refunds, 0);
       let superman_3 = 1; // rounding from fixed_point32
       assert!((*eve_donation_pro_rata + superman_3) == eve_donation, 7357008);
 
-      let eve_donation_pro_rata = vector::borrow(&refunds, 1);
+      let dave_donation_pro_rata = vector::borrow(&refunds, 1);
       let superman_3 = 1; // rounding from fixed_point32
-      assert!((*eve_donation_pro_rata + superman_3) == 21, 7357009);
+      assert!((*dave_donation_pro_rata + superman_3) == dave_donation, 7357009);
 
       let (_, program_balance_pre) = ol_account::balance(donor_directed_address);
       let (_, eve_balance_pre) = ol_account::balance(@0x1000e);
@@ -447,9 +451,14 @@ module ol_framework::test_donor_directed {
       assert!(program_balance < program_balance_pre, 7357010);
       assert!(program_balance == 0, 7357011);
 
+      // eve's account should not have changed.
+      // she does not get a refund, and the policy of the
+      // program says it goes to the matching index.
       assert!(eve_balance == eve_balance_pre, 7357010);
 
       let (lifetime_burn, _lifetime_match) = burn::get_lifetime_tracker();
+      print(&lifetime_burn);
+      // print(&lifetime_match);
       // nothing should have been burned, it was a refund
       assert!(lifetime_burn == 0, 7357011);
     }

--- a/framework/libra-framework/sources/ol_sources/tests/donor_directed.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/donor_directed.test.move
@@ -13,7 +13,7 @@ module ol_framework::test_donor_directed {
   use std::vector;
   use std::signer;
 
-  use diem_std::debug::print;
+  // use diem_std::debug::print;
 
     #[test(root = @ol_framework, alice = @0x1000a)]
     fun dd_init(root: &signer, alice: &signer) {
@@ -304,8 +304,11 @@ module ol_framework::test_donor_directed {
 
       let vals = mock::genesis_n_vals(root, 5); // need to include eve to init funds
       mock::ol_initialize_coin_and_fund_vals(root, 100000, true);
-      // start at epoch 1, since turnout tally needs epoch info, and 0 may cause issues
+      // start at epoch 1, since turnout tally needs epoch info, and 0 may cause
+      // issues
       mock::trigger_epoch(root);
+      // a burn happend in the epoch above, so let's compare it to end of epoch
+      let (lifetime_burn_pre, _) = burn::get_lifetime_tracker();
 
       let (resource_sig, _cap) = ol_account::ol_create_resource_account(alice, b"0x1");
       let donor_directed_address = signer::address_of(&resource_sig);
@@ -322,8 +325,9 @@ module ol_framework::test_donor_directed {
       let is_donor = donor_directed_governance::check_is_donor(donor_directed_address, signer::address_of(eve));
       assert!(is_donor, 7357002);
 
-      // Dave will also be a donor, with half the amount of what Eve sends
-      ol_account::transfer(dave, donor_directed_address, 21);
+      // Dave will also be a donor, with half the amount of what Eve
+      let dave_donation = 21;
+      ol_account::transfer(dave, donor_directed_address, dave_donation);
       let is_donor = donor_directed_governance::check_is_donor(donor_directed_address, signer::address_of(dave));
       assert!(is_donor, 7357003);
 
@@ -352,9 +356,9 @@ module ol_framework::test_donor_directed {
       let superman_3 = 1; // rounding from fixed_point32
       assert!((*eve_donation_pro_rata + superman_3) == eve_donation, 7357008);
 
-      let eve_donation_pro_rata = vector::borrow(&refunds, 1);
+      let dave_donation_pro_rata = vector::borrow(&refunds, 1);
       let superman_3 = 1; // rounding from fixed_point32
-      assert!((*eve_donation_pro_rata + superman_3) == 21, 7357009);
+      assert!((*dave_donation_pro_rata + superman_3) == dave_donation, 7357009);
 
 
       let (_, program_balance_pre) = ol_account::balance(donor_directed_address);
@@ -368,11 +372,12 @@ module ol_framework::test_donor_directed {
       assert!(program_balance < program_balance_pre, 7357010);
       assert!(program_balance == 0, 7357011);
 
+      // eve shoul have received funds back
       assert!(eve_balance > eve_balance_pre, 7357010);
 
-      let (lifetime_burn, _lifetime_match) = burn::get_lifetime_tracker();
+      let (lifetime_burn_now, _) = burn::get_lifetime_tracker();
       // nothing should have been burned, it was a refund
-      assert!(lifetime_burn == 0, 7357011);
+      assert!(lifetime_burn_now == lifetime_burn_pre, 7357011);
 
     }
 
@@ -387,6 +392,8 @@ module ol_framework::test_donor_directed {
       mock::ol_initialize_coin_and_fund_vals(root, 100000, true);
       // start at epoch 1, since turnout tally needs epoch info, and 0 may cause issues
       mock::trigger_epoch(root);
+      // a burn happend in the epoch above, so let's compare it to end of epoch
+      let (lifetime_burn_pre, _) = burn::get_lifetime_tracker();
 
       let (resource_sig, _cap) = ol_account::ol_create_resource_account(alice, b"0x1");
       let donor_directed_address = signer::address_of(&resource_sig);
@@ -456,11 +463,10 @@ module ol_framework::test_donor_directed {
       // program says it goes to the matching index.
       assert!(eve_balance == eve_balance_pre, 7357010);
 
-      let (lifetime_burn, _lifetime_match) = burn::get_lifetime_tracker();
-      print(&lifetime_burn);
-      // print(&lifetime_match);
+      let (lifetime_burn_now, _lifetime_match) = burn::get_lifetime_tracker();
+
       // nothing should have been burned, it was a refund
-      assert!(lifetime_burn == 0, 7357011);
+      assert!(lifetime_burn_now == lifetime_burn_pre, 7357011);
     }
 }
 

--- a/framework/libra-framework/sources/ol_sources/tests/rewards.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/rewards.test.move
@@ -1,15 +1,11 @@
 #[test_only]
 module ol_framework::test_rewards {
-  #[test_only]
   use ol_framework::rewards;
-  #[test_only]
   use ol_framework::gas_coin::{Self, LibraCoin as GasCoin};
-  #[test_only]
   use diem_framework::coin;
-  #[test_only]
   use ol_framework::mock;
-  #[test_only]
   use diem_framework::stake;
+  use ol_framework::burn;
 
   #[test(root = @ol_framework)]
   fun test_pay_reward_single(root: signer) {
@@ -58,6 +54,6 @@ module ol_framework::test_rewards {
     let b = coin::balance<GasCoin>(dave);
     assert!(b == 1000, 7357002);
 
-    coin::user_burn(new_coin);
+    burn::burn_and_track(new_coin);
   }
 }

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -29,6 +29,8 @@ pub fn make_framework_upgrade_artifacts(
     framework_local_dir: &Path,
     core_modules: &Option<Vec<String>>,
 ) -> Result<Vec<(String, String)>> {
+    let framework_git_hash = &get_framework_git_head(framework_local_dir).unwrap_or("none".to_owned());
+
     let deploy_to_account = AccountAddress::from_hex_literal(CORE_MODULE_ADDRESS)?;
 
     let mut next_execution_hash = vec![];
@@ -99,6 +101,7 @@ pub fn make_framework_upgrade_artifacts(
             deploy_to_account,
             this_mod_gov_script_path.clone(),
             next_execution_hash,
+            framework_git_hash,
         )?;
 
         // We need transaction execution hashes OF THE GOVERNANCE SCRIPT for the governance ceremony.
@@ -211,6 +214,16 @@ pub fn save_build(
         "success: governance script built at: {:?}",
         script_package_dir
     );
-    println!("hash: {:?}", hash.to_hex_literal());
+    println!("tx script hash: {:?}", hash.to_hex_literal());
     Ok(())
+}
+
+
+fn get_framework_git_head(path: &Path) -> anyhow::Result<String> {
+  let r = git2::Repository::discover(path).unwrap();
+  let id = r.head()?
+  .peel_to_commit()?
+  .id();
+
+  Ok(id.to_string())
 }

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -29,7 +29,8 @@ pub fn make_framework_upgrade_artifacts(
     framework_local_dir: &Path,
     core_modules: &Option<Vec<String>>,
 ) -> Result<Vec<(String, String)>> {
-    let framework_git_hash = &get_framework_git_head(framework_local_dir).unwrap_or("none".to_owned());
+    let framework_git_hash =
+        &get_framework_git_head(framework_local_dir).unwrap_or("none".to_owned());
 
     let deploy_to_account = AccountAddress::from_hex_literal(CORE_MODULE_ADDRESS)?;
 
@@ -218,12 +219,9 @@ pub fn save_build(
     Ok(())
 }
 
-
 fn get_framework_git_head(path: &Path) -> anyhow::Result<String> {
-  let r = git2::Repository::discover(path).unwrap();
-  let id = r.head()?
-  .peel_to_commit()?
-  .id();
+    let r = git2::Repository::discover(path).unwrap();
+    let id = r.head()?.peel_to_commit()?.id();
 
-  Ok(id.to_string())
+    Ok(id.to_string())
 }

--- a/framework/src/builder/framework_release_bundle.rs
+++ b/framework/src/builder/framework_release_bundle.rs
@@ -20,14 +20,12 @@ fn generate_blob(writer: &CodeWriter, data: &[u8]) {
 }
 
 pub fn libra_author_script_file(
-    //////// 0L //////// turn an MRB into a script proposal
+    //////// 0L //////// turn a compiled framework package into a script proposal
     release_package: &ReleasePackage,
     for_address: AccountAddress,
     out: PathBuf,
-    next_execution_hash: Vec<u8>, // metadata: Option<PackageMetadata>,
-                                  // is_testnet: bool,
-                                  // is_multi_step: bool,
-                                  // next_execution_hash: Vec<u8>,
+    next_execution_hash: Vec<u8>,
+    framework_git_hash: &str,
 ) -> anyhow::Result<()> {
     println!("autogenerating .move governance script file");
     let metadata = &release_package.metadata;
@@ -41,7 +39,7 @@ pub fn libra_author_script_file(
     emitln!(
         writer,
         "// Framework commit hash: {}\n// Builder commit hash: {}\n",
-        diem_build_info::get_git_hash(),
+        framework_git_hash,
         diem_build_info::get_git_hash(),
     );
     emitln!(
@@ -104,7 +102,7 @@ pub fn libra_author_script_file(
     emitln!(
         writer,
         "version::upgrade_set_git(&framework_signer, x\"{}\")",
-        diem_build_info::get_git_hash()
+        framework_git_hash
     );
 
     writer.unindent();


### PR DESCRIPTION
Fixes an informational struct which tracks global lifetime burns. 

The burn methods being used were not updating trackers.

Also has a minor change to genesis setting of consensus reward at genesis in case that was failing silently