### PR TITLE
fix(util): conditional sudo for some install_protoc commands

### DIFF
--- a/util/dev_setup.sh
+++ b/util/dev_setup.sh
@@ -159,15 +159,19 @@ function install_protoc {
     return
   fi
 
+  PRE_COMMAND=()
+  if [ "$(whoami)" != 'root' ]; then
+    PRE_COMMAND=(sudo)
+  fi
   TMPFILE=$(mktemp)
   rm "$TMPFILE"
   mkdir -p "$TMPFILE"/
   (
     cd "$TMPFILE" || exit
     curl -LOs "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_PKG.zip" --retry 3
-    sudo unzip -o "$PROTOC_PKG.zip" -d /usr/local bin/protoc
-    sudo unzip -o "$PROTOC_PKG.zip" -d /usr/local 'include/*'
-    sudo chmod +x "/usr/local/bin/protoc"
+    "${PRE_COMMAND[@]}" unzip -o "$PROTOC_PKG.zip" -d /usr/local bin/protoc
+    "${PRE_COMMAND[@]}" unzip -o "$PROTOC_PKG.zip" -d /usr/local 'include/*'
+    "${PRE_COMMAND[@]}" chmod +x "/usr/local/bin/protoc"
   )
   rm -rf "$TMPFILE"
 
@@ -203,7 +207,7 @@ function install_rustup {
       echo "Rustup is already installed, version: $VERSION"
     fi
   else
-	  curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     if [[ -n "${CARGO_HOME}" ]]; then
       PATH="${CARGO_HOME}/bin:${PATH}"
     else


### PR DESCRIPTION
This was failing when run by root

```
./util/dev_setup.sh: line 168: sudo: command not found
make: *** [Makefile:53: install] Error 127
```