### PR TITLE
[move] remove extra slow wallet tracking

### DIFF
--- a/framework/libra-framework/sources/ol_sources/ol_account.move
+++ b/framework/libra-framework/sources/ol_sources/ol_account.move
@@ -160,7 +160,6 @@ module ol_framework::ol_account {
       // both update burn tracker
       let c = withdraw(sender, amount);
       deposit_coins(to, c);
-      slow_wallet::maybe_track_slow_transfer(payer, to, amount);
     }
 
     // transfer with capability, and do appropriate checks on both sides, and track the slow wallet
@@ -171,7 +170,6 @@ module ol_framework::ol_account {
       // NOTE: these shoud update BurnTracker
       let c = withdraw_with_capability(cap, amount);
       deposit_coins(recipient, c);
-      slow_wallet::maybe_track_slow_transfer(payer, recipient, amount);
     }
 
     /// Withdraw a coin while tracking the unlocked withdraw
@@ -181,7 +179,6 @@ module ol_framework::ol_account {
       let limit = slow_wallet::unlocked_amount(payer);
       assert!(amount < limit, error::invalid_state(EINSUFFICIENT_BALANCE));
 
-      slow_wallet::maybe_track_unlocked_withdraw(payer, amount);
       let coin = coin::withdraw_with_capability(cap, amount);
       // the outgoing coins should trigger an update on this account
       // order matters here
@@ -206,7 +203,6 @@ module ol_framework::ol_account {
 
         let limit = slow_wallet::unlocked_amount(addr);
         assert!(amount <= limit, error::invalid_state(EINSUFFICIENT_BALANCE));
-        slow_wallet::maybe_track_unlocked_withdraw(addr, amount);
         let coin = coin::withdraw<LibraCoin>(sender, amount);
         // the outgoing coins should trigger an update on this account
         // order matters here

--- a/framework/libra-framework/sources/ol_sources/slow_wallet.move
+++ b/framework/libra-framework/sources/ol_sources/slow_wallet.move
@@ -235,7 +235,6 @@ module ol_framework::slow_wallet {
       exists<SlowWallet>(addr)
     }
 
-    // #[view]
     /// helper to get the unlocked and total balance. (unlocked, total)
     public(friend) fun balance(addr: address): (u64, u64) acquires SlowWallet{
       // this is a normal account, so return the normal balance
@@ -249,8 +248,6 @@ module ol_framework::slow_wallet {
       (total, total)
     }
 
-    #[view]
-    // TODO: Deprecate this function in favor of `balance`
     /// Returns the amount of unlocked funds for a slow wallet.
     public fun unlocked_amount(addr: address): u64 acquires SlowWallet{
       // this is a normal account, so return the normal balance
@@ -260,6 +257,17 @@ module ol_framework::slow_wallet {
       };
 
       coin::balance<LibraCoin>(addr)
+    }
+
+    #[view]
+    /// Returns the amount of slow wallet transfers tracked
+    public fun transferred_amount(addr: address): u64 acquires SlowWallet{
+      // this is a normal account, so return the normal balance
+      if (exists<SlowWallet>(addr)) {
+        let s = borrow_global<SlowWallet>(addr);
+        return s.transferred
+      };
+      0
     }
 
     #[view]


### PR DESCRIPTION
Slow wallet tracking for unlocked and transferred coins are 3x what they should be. Since `transfer` and `transfer_with_capability` already calls `transfer_check` which adjusts those numbers, these other functions should not call `slow_wallet::maybe_track_slow_transfer` unless there is another entry point for them.