### PR TITLE
[tools] patch account lookup starting with "0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5808,6 +5808,7 @@ dependencies = [
  "diem-global-constants",
  "diem-rest-client",
  "diem-sdk",
+ "diem-temppath",
  "diem-types",
  "dirs",
  "futures",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -33,3 +33,6 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+diem-temppath = { workspace = true }

--- a/types/src/legacy_types/app_cfg.rs
+++ b/types/src/legacy_types/app_cfg.rs
@@ -202,7 +202,7 @@ impl AppCfg {
 
         if let Some(n) = nickname {
             let found = self.user_profiles.iter().enumerate().find_map(|(i, e)| {
-                if e.nickname.contains(&n) || e.account.to_hex_literal().contains(&n) {
+                if e.nickname.contains(&n) || e.account.to_string().contains(&n) {
                     Some(i)
                 } else {
                     None
@@ -620,6 +620,28 @@ async fn test_create() {
         ..Default::default()
     };
     a.save_file().unwrap();
+}
+
+#[tokio::test]
+async fn test_init() {
+    use diem_temppath::TempPath;
+    let d = TempPath::new();
+    let a = AuthenticationKey::from_str("8603ba96e87b810cebbec1a0fd7ea06285f9eb352a3eabde992a5594fe80af40").unwrap();
+
+    let b = AuthenticationKey::from_str("052dea65ac80cd4b2b1318a9420dc1568819882769346d9acffdc0d731504c66").unwrap();
+
+    let mut app_cfg: AppCfg = AppCfg::init_app_configs(
+        a,
+        a.derived_address(),
+        Some(d.path().to_owned()),
+        None,
+        None,
+    ).unwrap();
+
+    app_cfg.maybe_add_profile(Profile::new(b, b.derived_address())).unwrap();
+    assert!(app_cfg.user_profiles.len() > 1);
+    let p = app_cfg.get_profile(Some("052dea65ac80".to_string())).unwrap();
+    assert!(p.auth_key == b);
 }
 
 #[test]


### PR DESCRIPTION
CLI tools and downstream users of lib were unable to unable to search libra.yaml profiles for an account using a substring starting with "0"