### PR TITLE
[move] performance metrics

### DIFF
--- a/framework/libra-framework/sources/modified_source/stake.move
+++ b/framework/libra-framework/sources/modified_source/stake.move
@@ -285,6 +285,20 @@ module diem_framework::stake {
     }
 
     #[view]
+    /// Get net proposals from address
+    /// @return:  u64:  the number of net proposals (success - fail)
+    public fun get_val_net_proposals(val: address): u64 acquires
+    ValidatorPerformance, ValidatorConfig {
+        let idx = get_validator_index(val);
+        let (proposed, failed) = get_current_epoch_proposal_counts(idx);
+        if (proposed > failed) {
+          proposed - failed
+        } else {
+          0
+        }
+    }
+
+    #[view]
     /// Return the validator's config.
     public fun get_validator_config(validator_address: address): (vector<u8>, vector<u8>, vector<u8>) acquires ValidatorConfig {
         assert_stake_pool_exists(validator_address);
@@ -341,9 +355,6 @@ module diem_framework::stake {
         if (account_address != operator) {
             set_operator(owner, operator)
         };
-        // if (account_address != voter) {
-        //     set_delegated_voter(owner, voter)
-        // };
     }
 
     /// Initialize the validator account and give ownership to the signing account.

--- a/framework/libra-framework/sources/modified_source/stake.move
+++ b/framework/libra-framework/sources/modified_source/stake.move
@@ -541,18 +541,9 @@ module diem_framework::stake {
     }
 
     /// Triggers at epoch boundary. This function shouldn't abort.
-    ///
-    /// 1. Distribute transaction fees and rewards to stake pools of active and pending inactive validators (requested
-    /// to leave but not yet removed).
-    /// 2. Officially move pending active stake to active and move pending inactive stake to inactive.
-    /// The staking pool's voting power in this new epoch will be updated to the total active stake.
-    /// 3. Add pending active validators to the active set if they satisfy requirements so they can vote and remove
-    /// pending inactive validators so they no longer can vote.
-    /// 4. The validator's voting power in the validator set is updated to be the corresponding staking pool's voting
-    // / power.
+    /// NOTE: THIS ONLY EXISTS FOR VENDOR TESTS
     public(friend) fun on_new_epoch() acquires ValidatorConfig, ValidatorPerformance, ValidatorSet {
         let validator_set = borrow_global_mut<ValidatorSet>(@diem_framework);
-        // let config = staking_config::get();
         let validator_perf = borrow_global_mut<ValidatorPerformance>(@diem_framework);
 
 
@@ -560,9 +551,7 @@ module diem_framework::stake {
         // Moreover, recalculate the total voting power, and deactivate the validator whose
         // voting power is less than the minimum required stake.
         let next_epoch_validators = vector::empty();
-        // let (minimum_stake, _) = staking_config::get_required_stake(&config);
         let minimum_stake = 0;
-
 
         let vlen = vector::length(&validator_set.active_validators);
         let total_voting_power = 0;
@@ -595,13 +584,8 @@ module diem_framework::stake {
         validator_set.total_voting_power = total_voting_power;
 
 
-        // validator_set.total_joining_power = 0;
-
         // Update validator indices, reset performance scores, and renew lockups.
         validator_perf.validators = vector::empty();
-        // let recurring_lockup_duration_secs = 0;
-        //staking_config::get_recurring_lockup_duration(&config);
-
 
         let vlen = vector::length(&validator_set.active_validators);
         let validator_index = 0;

--- a/framework/libra-framework/sources/ol_sources/grade.move
+++ b/framework/libra-framework/sources/ol_sources/grade.move
@@ -11,7 +11,7 @@ module ol_framework::grade {
     use diem_framework::stake;
     use std::fixed_point32::{Self, FixedPoint32};
 
-
+    use diem_std::debug::print;
     /// what threshold of failed props should the network allow
     /// one validator before jailing?
     const FAILED_PROPS_THRESHOLD_PCT: u64 = 20;
@@ -35,6 +35,9 @@ module ol_framework::grade {
         return (false, proposed, failed, fixed_point32::create_from_raw_value(0))
       };
 
+      print(&has_good_success_ratio(proposed, failed));
+      print(&does_not_trail(proposed, failed, highest_net_props));
+
       let compliant = has_good_success_ratio(proposed, failed) &&
       does_not_trail(proposed, failed, highest_net_props);
 
@@ -53,7 +56,8 @@ module ol_framework::grade {
         fixed_point32::create_from_rational(failed, proposed)
       } else { return false };
 
-      let is_above = fixed_point32::multiply_u64(100, fail_ratio) > FAILED_PROPS_THRESHOLD_PCT;
+      // failure ratio shoul dbe BELOW FAILED_PROPS_THRESHOLD_PCT
+      let is_above = fixed_point32::multiply_u64(100, fail_ratio) < FAILED_PROPS_THRESHOLD_PCT;
 
       is_above
 

--- a/framework/libra-framework/sources/ol_sources/grade.move
+++ b/framework/libra-framework/sources/ol_sources/grade.move
@@ -24,7 +24,11 @@ module ol_framework::grade {
     #[view]
     /// returns if the validator passed or failed, and the number of proposals
     /// and failures, and the ratio.
-    /// returns: is the validator compliant, proposed blocks, failed blocks, and the ratio of proposed to failed.
+    /// @return: tuple
+    /// bool: is the validator compliant,
+    /// u64: proposed blocks,
+    /// u64: failed blocks, and
+    /// FixedPoint32: the ratio of proposed to failed.
 
     public fun get_validator_grade(node_addr: address, highest_net_props: u64): (bool, u64, u64, FixedPoint32) {
       let idx = stake::get_validator_index(node_addr);

--- a/framework/libra-framework/sources/ol_sources/grade.move
+++ b/framework/libra-framework/sources/ol_sources/grade.move
@@ -12,6 +12,8 @@ module ol_framework::grade {
     use std::fixed_point32::{Self, FixedPoint32};
 
 
+    const FAILED_PROPS_THRESHOLD_PCT: u64 = 20;
+
     #[view]
     /// returns if the validator passed or failed, and the number of proposals
     /// and failures, and the ratio.
@@ -21,9 +23,55 @@ module ol_framework::grade {
       let idx = stake::get_validator_index(node_addr);
       let (proposed, failed) = stake::get_current_epoch_proposal_counts(idx);
 
-      let compliant = proposed > failed;
+      // first pass: should have accepted proposals
+      if (proposed < failed) {
+        return (false, proposed, failed, fixed_point32::create_from_raw_value(0))
+      };
+
+      let compliant = has_good_success_ratio(proposed, failed) &&
+      does_not_trail(proposed);
+
       // make failed at leat 1 to avoid division by zero
       (compliant, proposed, failed, fixed_point32::create_from_rational(proposed, (failed + 1)))
     }
 
+    /// Does the validator produce far more valid proposals than failed ones.
+    /// suggesting here an initial 80% threshold. (i.e. only allow 20% failed
+    /// proposals)
+    /// It's unclear what the right ratio should be. On problematic epochs
+    /// (i.e. low consensus) we may want to have some allowance for errors.
+    fun has_good_success_ratio(proposed: u64, failed: u64): bool {
+
+      let fail_ratio = if (proposed >= failed) {
+        fixed_point32::create_from_rational(failed, proposed)
+      } else { return false };
+
+      let is_above = fixed_point32::multiply_u64(100, fail_ratio) > FAILED_PROPS_THRESHOLD_PCT;
+
+      is_above
+
+    }
+
+    /// is this user very far behind the leading proposer.
+    /// in 0L we give all validator seats equal chances of proposing (leader).
+    /// However, the "leader reputation" algorithm in LibraBFT, will score
+    /// validators. The score is based on successful signing and propagation of
+    /// blocks. So people with lower scores might a) not be very competent or,
+    /// b) are in networks that are further removed from the majority (remote
+    /// data centers, home labs, etc). So we shouldn't bias too heavily on this
+    // performance metric, because it will reduce heterogeneity (the big D).
+    /// Unfortunately the reputation heuristic score is not on-chain
+    /// (perhaps a future optimization).
+    /// A good solution would be to drop the lowest % of RMS (root mean
+    /// squared) of proposal. Perhaps the lowest 10% of the validator set RMS.
+    /// But that's harder to understand by the validators (comprehension is
+    // important when we are trying to shape behavior).
+    /// So a simpler and more actionable metric might be:
+    /// drop anyone who proposed less than X% of the LEADING proposal.
+    /// This has an additional quality, which allows for the highest performing
+    // validators to be a kind of "vanguard" rider ("forerider"?) which sets the
+    // pace for the lowest performer.
+    fun does_not_trail(proposed: u64): bool {
+      proposed > 0
+    }
 }

--- a/framework/libra-framework/sources/ol_sources/grade.move
+++ b/framework/libra-framework/sources/ol_sources/grade.move
@@ -12,9 +12,10 @@ module ol_framework::grade {
     use std::fixed_point32::{Self, FixedPoint32};
 
     // use diem_std::debug::print;
+
     /// what threshold of failed props should the network allow
     /// one validator before jailing?
-    const FAILED_PROPS_THRESHOLD_PCT: u64 = 20;
+    const FAILED_PROPS_THRESHOLD_PCT: u64 =20;
 
     /// how far behind the leading validator by net proposals
     /// should the trailing validator be allowed

--- a/framework/libra-framework/sources/ol_sources/mock.move
+++ b/framework/libra-framework/sources/ol_sources/mock.move
@@ -52,9 +52,9 @@ module ol_framework::mock {
   #[test_only]
   public fun mock_case_1(vm: &signer, addr: address){
       assert!(stake::is_valid(addr), 01);
-      stake::mock_performance(vm, addr, 1, 0);
-      let (compliant, _, _, _) = grade::get_validator_grade(addr, 0);
-      assert!(compliant, 777703);
+      stake::mock_performance(vm, addr, 100, 10);
+      let (compliant, _, _, _) = grade::get_validator_grade(addr, 100);
+      assert!(compliant, 01);
     }
 
 
@@ -64,7 +64,7 @@ module ol_framework::mock {
       assert!(stake::is_valid(addr), 01);
       stake::mock_performance(vm, addr, 0, 100); // 100 failing proposals
       let (compliant, _, _, _) = grade::get_validator_grade(addr, 0);
-      assert!(!compliant, 777703);
+      assert!(!compliant, 02);
     }
 
     // Mock all nodes being compliant case 1
@@ -114,7 +114,7 @@ module ol_framework::mock {
       // make all validators pay auction fee
       // the clearing price in the fibonacci sequence is is 1
       let (alice_bid, _) = proof_of_fee::current_bid(*vector::borrow(&vals, 0));
-      assert!(alice_bid == 1, 777703);
+      assert!(alice_bid == 1, 03);
       (vals, bids, expiry)
     }
 
@@ -311,8 +311,6 @@ module ol_framework::mock {
 
   #[test(root = @ol_framework)]
   public entry fun meta_val_perf(root: signer) {
-    // genesis();
-
     let set = genesis_n_vals(&root, 4);
     assert!(vector::length(&set) == 4, 7357001);
 

--- a/framework/libra-framework/sources/ol_sources/mock.move
+++ b/framework/libra-framework/sources/ol_sources/mock.move
@@ -53,7 +53,7 @@ module ol_framework::mock {
   public fun mock_case_1(vm: &signer, addr: address){
       assert!(stake::is_valid(addr), 01);
       stake::mock_performance(vm, addr, 1, 0);
-      let (compliant, _, _, _) = grade::get_validator_grade(addr);
+      let (compliant, _, _, _) = grade::get_validator_grade(addr, 0);
       assert!(compliant, 777703);
     }
 
@@ -63,7 +63,7 @@ module ol_framework::mock {
     public fun mock_case_4(vm: &signer, addr: address){
       assert!(stake::is_valid(addr), 01);
       stake::mock_performance(vm, addr, 0, 100); // 100 failing proposals
-      let (compliant, _, _, _) = grade::get_validator_grade(addr);
+      let (compliant, _, _, _) = grade::get_validator_grade(addr, 0);
       assert!(!compliant, 777703);
     }
 

--- a/framework/libra-framework/sources/ol_sources/musical_chairs.move
+++ b/framework/libra-framework/sources/ol_sources/musical_chairs.move
@@ -148,11 +148,11 @@ module ol_framework::musical_chairs {
         // TODO: use status.move is_operating
         if (epoch < 2) return (validators, non_compliant_nodes, fixed_point32::create_from_rational(1, 1));
 
-
+        let (highest_net_props, _val) = stake::get_highest_net_proposer();
         let i = 0;
         while (i < val_set_len) {
             let addr = *vector::borrow(&validators, i);
-            let (compliant, _, _, _) = grade::get_validator_grade(addr);
+            let (compliant, _, _, _) = grade::get_validator_grade(addr, highest_net_props);
             // let compliant = true;
             if (compliant) {
                 vector::push_back(&mut compliant_nodes, addr);

--- a/framework/libra-framework/sources/ol_sources/tests/stake.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/stake.test.move
@@ -171,5 +171,54 @@ module ol_framework::test_stake {
 
   }
 
+  // Scenario: There's one validator that is a straggler
+  // that validator should be dropped when we "grade"
+  // the validators.
+  // The validator has an acceptable success ratio
+  #[test(root = @ol_framework)]
+  fun drop_trailing(root: signer) {
+
+    let set = mock::genesis_n_vals(&root, 8);
+    testnet::unset(&root); // set to production mode
+
+    let default_valid_props = 500;
+    // populate some performance
+    let i = 0;
+    while (i < vector::length(&set)) {
+      let addr = vector::borrow(&set, i);
+
+      let valid_props =  default_valid_props; // make all validators have
+      let invalid_props = 1;
+
+      stake::mock_performance(&root, *addr, valid_props, invalid_props); //
+      // increasing performance for each
+      i = i + 1;
+    };
+
+    // set alice to be "trailing"
+    // this will be less than 5% of the leading validator
+    stake::mock_performance(&root, @0x1000a, 5, 1);
+    stake::mock_performance(&root, @0x10011, 1000, 1);
+
+    let (highest_score, _addr) = stake::get_highest_net_proposer();
+
+    // LOWEST TRAILING VALIDATOR WILL BE OUT
+    let lowest_score = stake::get_val_net_proposals(@0x1000a);
+
+    assert!(highest_score > (lowest_score*20), 7357001);
+    let (a, _, _, _) = grade::get_validator_grade(@0x1000a, highest_score);
+    assert!(a == false, 73570002);
+
+    // Second lowest is fine
+    let (b, _, _, _) = grade::get_validator_grade(@0x1000c, highest_score);
+    assert!(b == true, 73570003);
+
+    // and top is also fine
+    let (top, _, _, _) = grade::get_validator_grade(@0x10011, highest_score);
+    assert!(top == true, 73570004);
+
+  }
+
+
 
 }

--- a/framework/libra-framework/sources/ol_sources/tests/stake.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/stake.test.move
@@ -166,7 +166,7 @@ module ol_framework::test_stake {
     // now make Eve not compliant
     let eve = @0x1000e;
     mock::mock_case_4(&root, eve);
-    let (compliant, _, _, _) = grade::get_validator_grade(eve);
+    let (compliant, _, _, _) = grade::get_validator_grade(eve, 0);
     assert!(!compliant, 735701);
 
   }

--- a/framework/libra-framework/sources/ol_sources/validator_universe.move
+++ b/framework/libra-framework/sources/ol_sources/validator_universe.move
@@ -1,5 +1,3 @@
-///////////////////////////////////////////////////////////////////////////
-// 0L Module
 // ValidatorUniverse
 ///////////////////////////////////////////////////////////////////////////
 
@@ -10,7 +8,6 @@ module diem_framework::validator_universe {
   use ol_framework::jail;
   use ol_framework::vouch;
   use diem_framework::stake;
-
 
   #[test_only]
   use ol_framework::testnet;
@@ -26,8 +23,6 @@ module diem_framework::validator_universe {
   struct ValidatorUniverse has key {
       validators: vector<address>
   }
-
-  // * DEPRECATED JailBit struct, now in jail.move * //
 
   // Genesis function to initialize ValidatorUniverse struct in 0x0.
   // This is triggered in new epoch by Configuration in Genesis.move


### PR DESCRIPTION
Some of our old logic for validator performance was not ported.  We have a gap in v5 and v7 performance metrics that are offered by the node platform. In V5 We were able to track VOTES on proposals, and in V7 we track PROPOSALS.

We have an issue that if a validator has 2 successful proposals and 1 failing proposal they will be "graded" as performant, event if there were one million blocks in the epoch. This is a bug.

- [x] adds conditions to grade.move has_good_success_ratio, does_not_trail
- [x] refactor existing tests
- [x] new tests