### PR TITLE
[Move] fix directory bug

### DIFF
--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -198,7 +198,13 @@ pub fn libra_compile_script(
 
     let hash = HashValue::sha3_256_of(bytes.as_slice());
 
-    save_build(script_package_dir.to_path_buf(), &bytes, &hash)?;
+    // we should send the parent directory, not the file path!
+    let parent_dir = script_package_dir.parent().ok_or(anyhow::anyhow!(
+        "could not get parent dir of {:?}",
+        script_package_dir
+    ))?;
+
+    save_build(parent_dir.to_path_buf(), &bytes, &hash)?;
 
     Ok((bytes, hash))
 }


### PR DESCRIPTION
Fixes a bug in the file directory composing function. In the bug, the `save_build` function appends the `script.mv` and `script_sha3` file names to the given `--file-path` path, which is the absolute path to the file including its file name. 

This PR solves that by sending the parent directory of the given `--file-path`.