### PR TITLE
Fix for arithmetic subtraction error in epoch_boundary

### DIFF
--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -243,19 +243,21 @@ module diem_framework::epoch_boundary {
 
           // since we reserved some fees to go to the oracle miners
           // we take the NET REWARD of the validators, since it is the equivalent of what the validator would earn net of entry fee.
-          let net_val_reward = nominal_reward_to_vals - entry_fee;
+            if (nominal_reward_to_vals > entry_fee) {
+                let net_val_reward = nominal_reward_to_vals - entry_fee;
 
-          if (coin::value(&all_fees) > net_val_reward) {
-            let oracle_budget = coin::extract(&mut all_fees, net_val_reward);
-            status.oracle_budget = coin::value(&oracle_budget);
+                if (coin::value(&all_fees) > net_val_reward) {
+                    let oracle_budget = coin::extract(&mut all_fees, net_val_reward);
+                    status.oracle_budget = coin::value(&oracle_budget);
 
-            let (count, amount) = oracle::epoch_boundary(root, &mut oracle_budget);
-            status.oracle_pay_count = count;
-            status.oracle_pay_amount = amount;
-            status.oracle_pay_success = (amount > 0);
-            // in case there is any dust left
-            ol_account::merge_coins(&mut all_fees, oracle_budget);
-          };
+                    let (count, amount) = oracle::epoch_boundary(root, &mut oracle_budget);
+                    status.oracle_pay_count = count;
+                    status.oracle_pay_amount = amount;
+                    status.oracle_pay_success = (amount > 0);
+                    // in case there is any dust left
+                    ol_account::merge_coins(&mut all_fees, oracle_budget);
+                };
+            };
 
           // remainder gets burnt according to fee maker preferences
           let (b_success, b_fees) = burn::epoch_burn_fees(root, &mut all_fees);

--- a/framework/libra-framework/sources/ol_sources/grade.move
+++ b/framework/libra-framework/sources/ol_sources/grade.move
@@ -90,7 +90,7 @@ module ol_framework::grade {
         let net = proposed - failed;
         let net_props_vs_leader= fixed_point32::create_from_rational(net,
         highest_net_props);
-        fixed_point32::multiply_u64(100, net_props_vs_leader) > FAILED_PROPS_THRESHOLD_PCT
+        fixed_point32::multiply_u64(100, net_props_vs_leader) > TRAILING_VALIDATOR_THRESHOLD
       } else { false }
     }
 }

--- a/framework/libra-framework/sources/ol_sources/tower_state.move
+++ b/framework/libra-framework/sources/ol_sources/tower_state.move
@@ -585,14 +585,20 @@ module ol_framework::tower_state {
         // pick the next miner
         // make sure we get an n smaller than list of miners
 
-        let k = 0; // k keeps track of this loop, abort if loops too much
-        while (this_miner_index > count_miners) {
-          if (k > 1000) return 0;
-          this_miner_index = this_miner_index / count_miners;
-          k = k + 1;
-        };
+        // Current case: if miner_index = count_miners could lead to overflow 
+
+        // let k = 0; // k keeps track of this loop, abort if loops too much
+        // while (this_miner_index >= count_miners) {
+        //   if (k > 1000) return 0;
+        //   this_miner_index = this_miner_index / count_miners;
+        //   k = k + 1;
+        // };
+
         // double check length of vector
-        if (this_miner_index >= count_miners ) return 0;
+        // if (this_miner_index >= count_miners ) return 0;
+
+        // We could use modulo arthemetic on integers
+        this_miner_index = this_miner_index % count_miners;
 
         let miner_addr = vector::borrow<address>(&all_miners, this_miner_index);
         let vec = if (exists<TowerProofHistory>(*miner_addr)) {


### PR DESCRIPTION
Fixes the 'ARITHMETIC_ERROR' we saw in the epoch 13->14 boundary halt. This is due to the case where the `entry fee` is larger than the actual validator reward given by the system. This causes an arithmetic error due to unsupported signed integers in Move. 

This PR also contains a commit by @sm86 which is already merged in main, and a  fix for a small incorrect variable usage in `grade.move`