### PR TITLE
[framework] use uniform build options for Move

### DIFF
--- a/framework/cached-packages/build.rs
+++ b/framework/cached-packages/build.rs
@@ -1,4 +1,4 @@
-use libra_framework::release::ReleaseTarget;
+use libra_framework::builder::release::ReleaseTarget;
 use std::{env::current_dir, path::PathBuf};
 
 fn main() {

--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -22,7 +22,9 @@ module diem_framework::epoch_boundary {
     use diem_framework::coin::{Self, Coin};
     use std::vector;
     use std::error;
+    use std::signer;
     use std::string;
+
 
     use diem_std::debug::print;
 
@@ -115,6 +117,9 @@ module diem_framework::epoch_boundary {
     }
 
     public fun initialize(framework: &signer) {
+      let addr = signer::address_of(framework);
+      if (addr != @ol_framework) return; // don't throw error.
+
       if (!exists<BoundaryStatus>(@ol_framework)){
         move_to(framework, reset());
       };

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -1,7 +1,10 @@
 //! generate framework upgrade proposal scripts
 //! see vendor diem-move/framework/src/release_bundle.rs
 
-use crate::{builder::{framework_release_bundle::libra_author_script_file, release::ol_release_default}, BYTECODE_VERSION};
+use crate::{
+    builder::{framework_release_bundle::libra_author_script_file, release::ol_release_default},
+    BYTECODE_VERSION,
+};
 use anyhow::{ensure, Context, Result};
 use diem_crypto::HashValue;
 use diem_framework::{BuildOptions, BuiltPackage, ReleasePackage};

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -1,7 +1,7 @@
 //! generate framework upgrade proposal scripts
 //! see vendor diem-move/framework/src/release_bundle.rs
 
-use crate::{builder::framework_release_bundle::libra_author_script_file, BYTECODE_VERSION};
+use crate::{builder::{framework_release_bundle::libra_author_script_file, release::ol_release_default}, BYTECODE_VERSION};
 use anyhow::{ensure, Context, Result};
 use diem_crypto::HashValue;
 use diem_framework::{BuildOptions, BuiltPackage, ReleasePackage};
@@ -56,15 +56,16 @@ pub fn make_framework_upgrade_artifacts(
 
         // We first need to compile and build each CORE MODULE we are upgrading (e.g. MoveStdlib, LibraFramework)
 
-        let options = BuildOptions {
-            with_srcs: true,         // this will store the source bytes on chain, as in genesis
-            with_abis: false,        // NOTE: this is set to false in vendor
-            with_source_maps: false, // NOTE: this is set to false in vendor
-            with_error_map: true,
-            skip_fetch_latest_git_deps: true,
-            bytecode_version: Some(BYTECODE_VERSION),
-            ..BuildOptions::default()
-        };
+        // let options = BuildOptions {
+        //     with_srcs: true,         // this will store the source bytes on chain, as in genesis
+        //     with_abis: false,        // NOTE: this is set to false in vendor
+        //     with_source_maps: false, // NOTE: this is set to false in vendor
+        //     with_error_map: true,
+        //     skip_fetch_latest_git_deps: true,
+        //     bytecode_version: Some(BYTECODE_VERSION),
+        //     ..BuildOptions::default()
+        // };
+        let options = ol_release_default();
 
         ensure!(
             core_module_dir.exists(),

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -1,12 +1,7 @@
 //! generate framework upgrade proposal scripts
 //! see vendor diem-move/framework/src/release_bundle.rs
 
-use crate::{
-    builder::{
-        framework_release_bundle::libra_author_script_file, named_addresses::named_addresses,
-    },
-    BYTECODE_VERSION,
-};
+use crate::{builder::framework_release_bundle::libra_author_script_file, BYTECODE_VERSION};
 use anyhow::{ensure, Context, Result};
 use diem_crypto::HashValue;
 use diem_framework::{BuildOptions, BuiltPackage, ReleasePackage};

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -1,7 +1,12 @@
 //! generate framework upgrade proposal scripts
 //! see vendor diem-move/framework/src/release_bundle.rs
 
-use crate::{builder::framework_release_bundle::libra_author_script_file, BYTECODE_VERSION};
+use crate::{
+    builder::{
+        framework_release_bundle::libra_author_script_file, named_addresses::named_addresses,
+    },
+    BYTECODE_VERSION,
+};
 use anyhow::{ensure, Context, Result};
 use diem_crypto::HashValue;
 use diem_framework::{BuildOptions, BuiltPackage, ReleasePackage};
@@ -57,8 +62,8 @@ pub fn make_framework_upgrade_artifacts(
         // We first need to compile and build each CORE MODULE we are upgrading (e.g. MoveStdlib, LibraFramework)
 
         let options = BuildOptions {
-            with_srcs: true, // this will store the source bytes on chain, as in genesis
-            with_abis: false, // NOTE: this is set to false in vendor
+            with_srcs: true,         // this will store the source bytes on chain, as in genesis
+            with_abis: false,        // NOTE: this is set to false in vendor
             with_source_maps: false, // NOTE: this is set to false in vendor
             with_error_map: true,
             skip_fetch_latest_git_deps: true,

--- a/framework/src/builder/framework_generate_upgrade_proposal.rs
+++ b/framework/src/builder/framework_generate_upgrade_proposal.rs
@@ -58,8 +58,8 @@ pub fn make_framework_upgrade_artifacts(
 
         let options = BuildOptions {
             with_srcs: true, // this will store the source bytes on chain, as in genesis
-            with_abis: false,
-            with_source_maps: false,
+            with_abis: false, // NOTE: this is set to false in vendor
+            with_source_maps: false, // NOTE: this is set to false in vendor
             with_error_map: true,
             skip_fetch_latest_git_deps: true,
             bytecode_version: Some(BYTECODE_VERSION),

--- a/framework/src/builder/mod.rs
+++ b/framework/src/builder/mod.rs
@@ -10,3 +10,5 @@
 // pub mod release_config_ext; // a trait to extend the release config struct see diem-move/diem-release-builder/src/components/mod.rs
 pub mod framework_generate_upgrade_proposal; // see diem-move/diem-release-builder/src/components/framework.rs
 pub mod framework_release_bundle; // note this lives in a different module in vendor. see diem-move/framework/src/release_bundle.rs
+pub mod named_addresses; // OL uses different names for addresses
+pub mod release; // OL uses different names for addresses

--- a/framework/src/builder/named_addresses.rs
+++ b/framework/src/builder/named_addresses.rs
@@ -1,4 +1,4 @@
-use move_command_line_common::address::NumericalAddress;
+use diem_types::account_address::AccountAddress;
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 
@@ -8,13 +8,13 @@ use std::collections::BTreeMap;
 // Some older Move tests work directly on sources, skipping the package system. For those
 // we define the relevant address aliases here.
 
-static NAMED_ADDRESSES: Lazy<BTreeMap<String, NumericalAddress>> = Lazy::new(|| {
+pub static NAMED_ADDRESSES: Lazy<BTreeMap<String, AccountAddress>> = Lazy::new(|| {
     let mut result = BTreeMap::new();
-    let zero = NumericalAddress::parse_str("0x0").unwrap();
-    let one = NumericalAddress::parse_str("0x1").unwrap();
-    let three = NumericalAddress::parse_str("0x3").unwrap();
-    let four = NumericalAddress::parse_str("0x4").unwrap();
-    let resources = NumericalAddress::parse_str("0xA550C18").unwrap();
+    let zero = AccountAddress::from_hex_literal("0x0").unwrap();
+    let one = AccountAddress::from_hex_literal("0x1").unwrap();
+    let three = AccountAddress::from_hex_literal("0x3").unwrap();
+    let four = AccountAddress::from_hex_literal("0x4").unwrap();
+    let resources = AccountAddress::from_hex_literal("0xA550C18").unwrap();
     result.insert("std".to_owned(), one);
     result.insert("diem_std".to_owned(), one);
     result.insert("diem_framework".to_owned(), one);
@@ -26,6 +26,6 @@ static NAMED_ADDRESSES: Lazy<BTreeMap<String, NumericalAddress>> = Lazy::new(|| 
     result
 });
 
-pub fn named_addresses() -> &'static BTreeMap<String, NumericalAddress> {
+pub fn named_addresses() -> &'static BTreeMap<String, AccountAddress> {
     &NAMED_ADDRESSES
 }

--- a/framework/src/builder/named_addresses.rs
+++ b/framework/src/builder/named_addresses.rs
@@ -1,0 +1,31 @@
+use move_command_line_common::address::NumericalAddress;
+use once_cell::sync::Lazy;
+use std::collections::BTreeMap;
+
+// ===============================================================================================
+// Legacy Named Addresses
+
+// Some older Move tests work directly on sources, skipping the package system. For those
+// we define the relevant address aliases here.
+
+static NAMED_ADDRESSES: Lazy<BTreeMap<String, NumericalAddress>> = Lazy::new(|| {
+    let mut result = BTreeMap::new();
+    let zero = NumericalAddress::parse_str("0x0").unwrap();
+    let one = NumericalAddress::parse_str("0x1").unwrap();
+    let three = NumericalAddress::parse_str("0x3").unwrap();
+    let four = NumericalAddress::parse_str("0x4").unwrap();
+    let resources = NumericalAddress::parse_str("0xA550C18").unwrap();
+    result.insert("std".to_owned(), one);
+    result.insert("diem_std".to_owned(), one);
+    result.insert("diem_framework".to_owned(), one);
+    result.insert("diem_token".to_owned(), three);
+    result.insert("diem_token_objects".to_owned(), four);
+    result.insert("core_resources".to_owned(), resources);
+    result.insert("vm_reserved".to_owned(), zero);
+    result.insert("ol_framework".to_owned(), one); /////// 0L /////////
+    result
+});
+
+pub fn named_addresses() -> &'static BTreeMap<String, NumericalAddress> {
+    &NAMED_ADDRESSES
+}

--- a/framework/src/builder/release.rs
+++ b/framework/src/builder/release.rs
@@ -6,10 +6,8 @@
 use diem_framework::{
     docgen::DocgenOptions, BuildOptions, ReleaseBundle, ReleaseOptions, RELEASE_BUNDLE_EXTENSION,
 };
-// use clap::Args;
-use move_command_line_common::address::NumericalAddress;
-use once_cell::sync::Lazy;
-use std::{collections::BTreeMap, fmt::Display, path::PathBuf, str::FromStr};
+
+use std::{fmt::Display, path::PathBuf, str::FromStr};
 
 use crate::BYTECODE_VERSION;
 
@@ -156,32 +154,4 @@ impl ReleaseTarget {
                 .expect("Expected to join release thread")
         }
     }
-}
-
-// ===============================================================================================
-// Legacy Named Addresses
-
-// Some older Move tests work directly on sources, skipping the package system. For those
-// we define the relevant address aliases here.
-
-static NAMED_ADDRESSES: Lazy<BTreeMap<String, NumericalAddress>> = Lazy::new(|| {
-    let mut result = BTreeMap::new();
-    let zero = NumericalAddress::parse_str("0x0").unwrap();
-    let one = NumericalAddress::parse_str("0x1").unwrap();
-    let three = NumericalAddress::parse_str("0x3").unwrap();
-    let four = NumericalAddress::parse_str("0x4").unwrap();
-    let resources = NumericalAddress::parse_str("0xA550C18").unwrap();
-    result.insert("std".to_owned(), one);
-    result.insert("diem_std".to_owned(), one);
-    result.insert("diem_framework".to_owned(), one);
-    result.insert("diem_token".to_owned(), three);
-    result.insert("diem_token_objects".to_owned(), four);
-    result.insert("core_resources".to_owned(), resources);
-    result.insert("vm_reserved".to_owned(), zero);
-    result.insert("ol_framework".to_owned(), one); /////// 0L /////////
-    result
-});
-
-pub fn named_addresses() -> &'static BTreeMap<String, NumericalAddress> {
-    &NAMED_ADDRESSES
 }

--- a/framework/src/builder/release.rs
+++ b/framework/src/builder/release.rs
@@ -114,13 +114,6 @@ impl ReleaseTarget {
             .collect::<Vec<_>>();
         ReleaseOptions {
             build_options: BuildOptions {
-                // dev: false,
-                // with_srcs,
-                // with_abis: true,
-                // with_source_maps: true,
-                // with_error_map: true,
-                // named_addresses: Default::default(), // TODO: should this be NAMED_ADDRESSES
-                // install_dir: None,
                 with_docs: true,
                 docgen_options: Some(DocgenOptions {
                     include_impl: true,

--- a/framework/src/builder/release.rs
+++ b/framework/src/builder/release.rs
@@ -11,6 +11,28 @@ use std::{fmt::Display, path::PathBuf, str::FromStr};
 
 use crate::BYTECODE_VERSION;
 
+use super::named_addresses::NAMED_ADDRESSES;
+
+// BuilderOptions Helper
+
+/// The default build profile for the compiled move
+/// framework bytecode (.mrb file)
+pub fn ol_release_default() -> BuildOptions {
+    BuildOptions {
+        dev: false,
+        with_srcs: true,
+        with_abis: true,
+        with_source_maps: true,
+        with_error_map: true,
+        named_addresses: NAMED_ADDRESSES.to_owned(),
+        install_dir: None,
+        with_docs: false,
+        docgen_options: None,
+        skip_fetch_latest_git_deps: true,
+        bytecode_version: Some(BYTECODE_VERSION),
+    }
+}
+
 // ===============================================================================================
 // Release Targets
 
@@ -80,7 +102,7 @@ impl ReleaseTarget {
         ReleaseBundle::read(path)
     }
 
-    pub fn create_release_options(self, with_srcs: bool, out: Option<PathBuf>) -> ReleaseOptions {
+    pub fn create_release_options(self, _with_srcs: bool, out: Option<PathBuf>) -> ReleaseOptions {
         let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         // let crate_dir = crate_dir.parent().unwrap().to_path_buf();
         let packages = self
@@ -92,13 +114,13 @@ impl ReleaseTarget {
             .collect::<Vec<_>>();
         ReleaseOptions {
             build_options: BuildOptions {
-                dev: false,
-                with_srcs,
-                with_abis: true,
-                with_source_maps: true,
-                with_error_map: true,
-                named_addresses: Default::default(), // TODO: should this be NAMED_ADDRESSES
-                install_dir: None,
+                // dev: false,
+                // with_srcs,
+                // with_abis: true,
+                // with_source_maps: true,
+                // with_error_map: true,
+                // named_addresses: Default::default(), // TODO: should this be NAMED_ADDRESSES
+                // install_dir: None,
                 with_docs: true,
                 docgen_options: Some(DocgenOptions {
                     include_impl: true,
@@ -109,8 +131,7 @@ impl ReleaseTarget {
                     landing_page_template: Some("doc_template/overview.md".to_string()),
                     references_file: Some("doc_template/references.md".to_string()),
                 }),
-                skip_fetch_latest_git_deps: true,
-                bytecode_version: Some(BYTECODE_VERSION),
+                ..ol_release_default()
             },
             packages: packages.iter().map(|(path, _)| path.to_owned()).collect(),
             rust_bindings: packages

--- a/framework/src/framework_cli.rs
+++ b/framework/src/framework_cli.rs
@@ -1,7 +1,7 @@
 //! framework cli entry points
 
-use crate::{
-    builder::framework_generate_upgrade_proposal::{
+use crate::builder::{
+    framework_generate_upgrade_proposal::{
         init_move_dir_wrapper, libra_compile_script, make_framework_upgrade_artifacts, save_build,
     },
     release::ReleaseTarget,

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -1,12 +1,12 @@
 pub mod builder;
 pub mod framework_cli;
-pub mod release;
+// pub mod release;
 pub mod upgrade_fixtures;
 
 //////// 0L ///////
 /// Returns the release bundle for the current code.
 pub fn head_release_bundle() -> diem_framework::ReleaseBundle {
-    release::ReleaseTarget::Head
+    builder::release::ReleaseTarget::Head
         .load_bundle()
         .expect("release build failed")
 }

--- a/framework/src/release.rs
+++ b/framework/src/release.rs
@@ -64,16 +64,7 @@ impl ReleaseTarget {
                 "libra-framework",
                 Some("cached-packages/src/libra_framework_sdk_builder.rs"),
             ),
-            // (
-            //     "diem-token",
-            //     Some("cached-packages/src/diem_token_sdk_builder.rs"),
-            // ),
-            // (
-            //     "diem-token-objects",
-            //     Some("cached-packages/src/diem_token_objects_sdk_builder.rs"),
-            // ),
         ];
-        // Currently we don't have experimental packages only included in particular targets.
         result
     }
 
@@ -106,9 +97,9 @@ impl ReleaseTarget {
                 dev: false,
                 with_srcs,
                 with_abis: true,
-                with_source_maps: false,
+                with_source_maps: true,
                 with_error_map: true,
-                named_addresses: Default::default(),
+                named_addresses: Default::default(), // TODO: should this be NAMED_ADDRESSES
                 install_dir: None,
                 with_docs: true,
                 docgen_options: Some(DocgenOptions {

--- a/smoke-tests/src/libra_smoke.rs
+++ b/smoke-tests/src/libra_smoke.rs
@@ -6,7 +6,7 @@ use diem_forge::{LocalSwarm, Node, Swarm};
 use diem_sdk::types::LocalAccount;
 use diem_temppath::TempPath;
 use diem_types::chain_id::NamedChain;
-use libra_framework::release::ReleaseTarget;
+use libra_framework::builder::release::ReleaseTarget;
 use libra_types::exports::AccountAddress;
 use libra_types::exports::Client;
 use libra_types::legacy_types::app_cfg::AppCfg;

--- a/smoke-tests/tests/balance.rs
+++ b/smoke-tests/tests/balance.rs
@@ -1,6 +1,6 @@
 use diem_forge::Swarm;
 use diem_sdk::types::LocalAccount;
-use libra_framework::release::ReleaseTarget;
+use libra_framework::builder::release::ReleaseTarget;
 use libra_smoke_tests::helpers::{get_libra_balance, mint_libra};
 use smoke_test::smoke_test_environment::new_local_swarm_with_release;
 

--- a/smoke-tests/tests/meta.rs
+++ b/smoke-tests/tests/meta.rs
@@ -2,7 +2,7 @@ use libra_smoke_tests::libra_smoke::LibraSmoke;
 
 use diem_forge::Swarm;
 use libra_cached_packages::libra_stdlib;
-use libra_framework::release::ReleaseTarget;
+use libra_framework::builder::release::ReleaseTarget;
 use smoke_test::smoke_test_environment::new_local_swarm_with_release;
 
 /// testing that we can get a swarm up of 1 node with the current head.mrb

--- a/tools/genesis/src/genesis_builder.rs
+++ b/tools/genesis/src/genesis_builder.rs
@@ -36,7 +36,7 @@ use diem_vm_genesis::{
     default_gas_schedule,
     GenesisConfiguration as VmGenesisGenesisConfiguration, // in vendor codethere are two structs separately called the same name with nearly identical fields
 };
-use libra_framework::release;
+use libra_framework::builder::release;
 use libra_types::exports::ChainId;
 use libra_types::exports::NamedChain;
 use libra_types::legacy_types::fixtures::TestPersona;


### PR DESCRIPTION

Bundles for release and upgrade had different options (abi, error_map, source_map). 
There was also an issue with named addresses like @ol_framework, not being picked up on upgrade bundles.