### PR TITLE
[deps] update diem deps to 1.6.2-diem.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "serde 1.0.163",
  "serde_bytes",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "futures",
  "tokio",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "shadow-rs",
 ]
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "diem-framework",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anstyle",
  "clap 4.4.2",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-crypto",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "backtrace",
  "diem-logger",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
@@ -2344,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2416,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "thiserror",
 ]
@@ -2445,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2479,7 +2479,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "again",
  "anyhow",
@@ -2549,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "move-core-types",
 ]
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2690,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-proxy",
  "serde 1.0.163",
@@ -2702,17 +2702,17 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2751,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -2788,12 +2788,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2816,7 +2816,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2842,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-runtimes",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "hex",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "chrono",
 ]
@@ -3029,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3061,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "claims",
@@ -3250,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "proc-macro2 1.0.59",
  "quote 1.0.28",
@@ -3260,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3286,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "cfg_block",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "pbjson",
  "prost",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "ipnet",
 ]
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "tokio",
 ]
@@ -3540,7 +3540,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3595,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3634,7 +3634,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3646,7 +3646,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "mirai-annotations",
  "serde 1.0.163",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3710,11 +3710,13 @@ dependencies = [
  "diem-runtimes",
  "diem-schemadb",
  "diem-scratchpad",
+ "diem-sdk",
  "diem-storage-interface",
  "diem-time-service",
  "diem-types",
  "futures",
  "once_cell",
+ "reqwest",
  "serde 1.0.163",
  "thiserror",
  "tokio",
@@ -3724,7 +3726,7 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3738,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3765,7 +3767,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3779,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "bytes",
@@ -3805,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "diem-compression",
@@ -3820,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3829,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3842,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "again",
  "anyhow",
@@ -3873,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "again",
  "anyhow",
@@ -3903,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -3935,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3968,12 +3970,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3994,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "base64 0.13.0",
  "chrono",
@@ -4010,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -4057,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -4078,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4094,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4107,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4122,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6183,7 +6185,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6200,7 +6202,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6217,12 +6219,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6237,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6249,7 +6251,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6263,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -6280,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6324,7 +6326,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "difference",
@@ -6341,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6370,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6392,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6412,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -6430,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6449,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6463,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6482,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6501,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "hex",
@@ -6514,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "hex",
@@ -6528,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6555,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6591,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6628,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6657,7 +6659,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6672,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6698,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "hex",
@@ -6721,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "once_cell",
  "serde 1.0.163",
@@ -6730,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
@@ -6747,7 +6749,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -6778,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6808,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6825,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6839,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "bcs 0.1.4 (git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d)",
  "move-binary-format",
@@ -9036,7 +9038,7 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=db1137ba1#db1137ba1f8e7301e325021f71f740063daaf76e"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?rev=8725477#87254776b7dcf074015034e07b1a95891363b047"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,38 +42,38 @@ libra-txs = { path = "tools/txs" }
 libra-wallet = { path = "tools/wallet" }
 vdf = { git = "https://github.com/0o-de-lally/verifiable_delay.git" }
 
-diem-api-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-debugger = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-db = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-forge = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-transactional-test-harness = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-smoke-test = { package = "smoke-test", git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
+diem-api-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-debugger = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-db = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-forge = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-transactional-test-harness = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+smoke-test = { package = "smoke-test", git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
 
-diem = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-build-info = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-node = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-rest-client = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-sdk = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-config = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-crypto = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-genesis = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-global-constants = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-keygen = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-logger = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-gas = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-vm = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-vm-genesis = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-vm-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-executor = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-framework = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-cached-packages = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-github-client = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-release-builder = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-language-e2e-tests = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-state-view = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-storage-interface = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-diem-temppath = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
+diem = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-build-info = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-node = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-rest-client = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-sdk = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-config = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-crypto = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-genesis = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-global-constants = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-keygen = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-logger = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-gas = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-vm = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-vm-genesis = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-vm-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-executor = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-framework = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-cached-packages = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-github-client = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-release-builder = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-language-e2e-tests = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-state-view = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-storage-interface = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+diem-temppath = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
 
 ### External crate dependencies.
 # 0L NOTE: most of these are not used. But we leave the entire block here
@@ -316,13 +316,13 @@ serde_with = "^3"
 # move-abigen = { path = "third_party/move/move-prover/move-abigen" }
 # move-binary-format = { path = "third_party/move/move-binary-format" }
 # ... see full list in Aptos repo
-move-binary-format = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-core-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-command-line-common = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-compiler = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-model = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-vm-test-utils = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
-move-vm-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
+move-binary-format = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-core-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-command-line-common = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-compiler = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-model = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-vm-test-utils = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
+move-vm-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
 
 # uses a profile similar to `cli` in Diem/Cargo.toml
 # optimized for performance and size

--- a/framework/cached-packages/Cargo.toml
+++ b/framework/cached-packages/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 bcs = { workspace = true }
 # Note the generated SDK code uses hard coded `diemtypes`
-diem-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "db1137ba1" }
+diem-types = { git = "https://github.com/0LNetworkCommunity/diem.git", rev = "8725477" }
 move-core-types = { workspace = true }
 once_cell = { workspace = true }
 


### PR DESCRIPTION
Include from diem patch 1

[execution] governance::trigger_epoch() should not evaluate gas use
https://github.com/0LNetworkCommunity/diem/pull/5

[sync] out of the set validators fall back to fullnode network
https://github.com/0LNetworkCommunity/diem/pull/4