### PR TITLE
[feature] allow exempted addresses to upgrade framework with any policy

### DIFF
--- a/framework/libra-framework/sources/code.move
+++ b/framework/libra-framework/sources/code.move
@@ -161,14 +161,16 @@ module diem_framework::code {
         // Sayin', ("This is my message to you-ou-ou:")
         );
 
+        let addr = signer::address_of(owner);
+
         // Disallow incompatible upgrade mode. Governance can decide later if
         // this should be reconsidered.
         assert!(
+            is_policy_exempted_address(addr) ||
             pack.upgrade_policy.policy > upgrade_policy_arbitrary().policy,
             error::invalid_argument(EINCOMPATIBLE_POLICY_DISABLED),
         );
 
-        let addr = signer::address_of(owner);
         if (!exists<PackageRegistry>(addr)) {
             move_to(owner, PackageRegistry { packages: vector::empty() })
         };


### PR DESCRIPTION
Allow exempted addresses to upgrade framework with any policy. This allows to bypass upgrades with incompatibility issues by changing the upgrade policy in metadata. 

Example(`Move.toml`):

```
[package]
name = "LibraFramework"
version = "1.0.0"
<--------HERE--------->
upgrade_policy = "arbitrary"
<--------HERE--------->

[addresses]
std = "0x1"
diem_std = "0x1"
diem_framework = "0x1"
diem_token = "0x3"
core_resources = "0xA550C18"
vm_reserved = "0x0"
ol_framework = "0x1"
root = "0x1"

[dependencies]
VendorStdlib = { local = "../vendor-stdlib" }
```