### PR TITLE
Add scheduled CI run every 24h

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
     branches:
       - "release**"
       - "main**"
+  schedule:
+    - cron:  '30 00 * * *'
+
 env:
   DIEM_FORGE_NODE_BIN_PATH: ${{github.workspace}}/diem-node
   LIBRA_CI: 1


### PR DESCRIPTION
Testing this first on the main CI job. If it works we should add the lint job on a schedule too.