### PR TITLE
[ci] flag to skip framework upgrade compatibility checks [breaking]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,20 +221,42 @@ jobs:
           name: framework-build
           path: framework/
 
+      - name: Check if last commit on main has breaking tag
+        id: check_breaking_tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const octokit = require('@actions/github').getOctokit(process.env.GITHUB_TOKEN);
+            const { data: commits } = await octokit.rest.repos.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: 'main',
+              per_page: 1
+            });
+            const lastCommit = commits[0];
+            const { data: tags } = await octokit.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const hasBreakingTag = tags.some(tag => tag.name === 'breaking' && tag.commit.sha === lastCommit.sha);
+            core.setOutput('hasBreakingTag', hasBreakingTag);
+
+      - name: Print main last commit tag condition
+        run: |
+          echo "Main last commit has tag breaking: ${{ steps.check_breaking_tag.outputs.hasBreakingTag }}"
+
       - name: upgrade - check workflow
         if: always()
         working-directory: ./upgrade-tests
-        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with the default rust stack size.
+        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with o tamanho padrão da pilha
         run: RUST_MIN_STACK=104857600 cargo test --no-fail-fast -- --skip compatible_
 
       - name: upgrade - should be backwards compatible
         # should always run unless we explicitly mark the branch or tag as "breaking"
-        if: ${{ !contains(steps.get_branch.outputs.branch, 'breaking/') }}
+        if: ${{ !steps.check_breaking_tag.outputs.hasBreakingTag && !contains(steps.get_branch.outputs.branch, 'breaking/') }}
         working-directory: ./upgrade-tests
         # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow com o tamanho padrão da pilha
-        run: |
-          echo "Branch name inside check: ${{ steps.get_branch.outputs.branch }}"
-          RUST_MIN_STACK=104857600 cargo test compatible_
+        run: RUST_MIN_STACK=104857600 cargo test compatible_
 
   rescue:
     timeout-minutes: 60

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -221,41 +221,34 @@ jobs:
           name: framework-build
           path: framework/
 
-      - name: Check if last commit on main has breaking tag
-        id: check_breaking_tag
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const octokit = require('@actions/github').getOctokit(process.env.GITHUB_TOKEN);
-            const { data: commits } = await octokit.rest.repos.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: 'main',
-              per_page: 1
-            });
-            const lastCommit = commits[0];
-            const { data: tags } = await octokit.rest.repos.listTags({
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            const hasBreakingTag = tags.some(tag => tag.name === 'breaking' && tag.commit.sha === lastCommit.sha);
-            core.setOutput('hasBreakingTag', hasBreakingTag);
+      - name: Fetch main branch
+        run: git fetch origin main
 
-      - name: Print main last commit tag condition
+      - name: Check if last commit on main has [breaking] in the message
+        id: check_breaking_commit
         run: |
-          echo "Main last commit has tag breaking: ${{ steps.check_breaking_tag.outputs.hasBreakingTag }}"
+          LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B origin/main)
+          if echo "$LAST_COMMIT_MESSAGE" | grep -q "\[breaking\]"; then
+            echo "hasBreakingCommit=true" >> $GITHUB_ENV
+          else
+            echo "hasBreakingCommit=false" >> $GITHUB_ENV
+          fi
+
+      - name: Print main last commit message condition
+        run: |
+          echo "Main last commit has [breaking]: ${{ env.hasBreakingCommit }}"
 
       - name: upgrade - check workflow
         if: always()
         working-directory: ./upgrade-tests
-        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with o tamanho padrão da pilha
+        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with the default rust stack size.
         run: RUST_MIN_STACK=104857600 cargo test --no-fail-fast -- --skip compatible_
 
       - name: upgrade - should be backwards compatible
         # should always run unless we explicitly mark the branch or tag as "breaking"
-        if: ${{ !steps.check_breaking_tag.outputs.hasBreakingTag && !contains(steps.get_branch.outputs.branch, 'breaking/') }}
+        if: ${{ env.hasBreakingCommit == 'false' && !contains(steps.get_branch.outputs.branch, 'breaking/') }}
         working-directory: ./upgrade-tests
-        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow com o tamanho padrão da pilha
+        # NOTE: upgrade tests which compile Move code, and then submit in the same thread will cause a stack overflow with the default rust stack size.
         run: RUST_MIN_STACK=104857600 cargo test compatible_
 
   rescue:


### PR DESCRIPTION

Skip running compatible smoke tests in two cases:
1. the branch is named `breaking/xyz`
2. the last commit on `main`contains the string "[breaking]".

Note: when a dev submits a.PR with known backward *incompatible* changes, they must add "[breaking]" to the PR title so that the CI will ignore compatibility check (otherwise it appears as an unexpected failure, when it is actually expected behavior).