### PR TITLE
[testnet] rescue tools takes a list of validator registrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5812,6 +5812,7 @@ dependencies = [
  "hex",
  "indoc",
  "libra-cached-packages",
+ "libra-config",
  "libra-framework",
  "libra-query",
  "libra-smoke-tests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,7 @@ name = "libra-config"
 version = "7.0.2"
 dependencies = [
  "anyhow",
+ "bcs 0.1.4",
  "clap 4.5.4",
  "dialoguer",
  "diem",

--- a/tools/config/Cargo.toml
+++ b/tools/config/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bcs = { workspace = true }
 clap = { workspace = true }
 dialoguer = { workspace = true }
 diem = { workspace = true }

--- a/tools/config/src/lib.rs
+++ b/tools/config/src/lib.rs
@@ -4,3 +4,4 @@ pub mod make_profile; // TODO: deprecated?
 pub mod make_yaml_public_fullnode;
 pub mod make_yaml_validator;
 pub mod validator_config;
+pub mod validator_registration;

--- a/tools/config/src/validator_registration.rs
+++ b/tools/config/src/validator_registration.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+use anyhow::{self, Context};
+use diem_genesis::config::OperatorConfiguration;
+use libra_types::global_config_dir;
+use libra_wallet::validator_files::OPERATOR_FILE;
+use std::fs;
+
+/// Public data structure for validators to register their nodes on chain
+/// creating this depends on access to private keys.
+///
+// TODO: this matches the  libra framework sdk ValidatorUniverseRegisterValidator, there may be other duplications elsewhere.
+pub struct ValRegistrationPublic {
+    /// key for signing consensus transactions
+    pub consensus_pubkey: Vec<u8>,
+    /// proof that the node is in possession of the keys
+    pub proof_of_possession: Vec<u8>,
+    /// network addresses for consensus
+    pub network_addresses: Vec<u8>,
+    /// network addresses for public validator fullnode
+    pub fullnode_addresses: Vec<u8>,
+}
+
+pub fn registration_from_file(operator_keyfile: Option<PathBuf>) -> anyhow::Result<ValRegistrationPublic> {
+    let file = operator_keyfile.to_owned().unwrap_or_else(|| {
+        let a = global_config_dir();
+        a.join(OPERATOR_FILE)
+    });
+
+    let yaml_str = fs::read_to_string(file)?;
+    let oc: OperatorConfiguration = serde_yaml::from_str(&yaml_str)?;
+
+    let val_net_protocol = oc
+        .validator_host
+        .as_network_address(oc.validator_network_public_key)?;
+
+    let fullnode_host = oc
+        .full_node_host
+        .context("cannot find fullnode host in operator config file")?;
+    let vfn_fullnode_protocol = fullnode_host.as_network_address(
+        oc.full_node_network_public_key
+            .context("cannot find fullnode network public key in operator config file")?,
+    )?;
+
+    Ok(ValRegistrationPublic {
+        consensus_pubkey: oc.consensus_public_key.to_bytes().to_vec(),
+        proof_of_possession: oc.consensus_proof_of_possession.to_bytes().to_vec(),
+        network_addresses: bcs::to_bytes(&vec![val_net_protocol])?,
+        fullnode_addresses: bcs::to_bytes(&vec![vfn_fullnode_protocol])?,
+    })
+}

--- a/tools/config/src/validator_registration.rs
+++ b/tools/config/src/validator_registration.rs
@@ -1,15 +1,22 @@
-use std::path::PathBuf;
 use anyhow::{self, Context};
 use diem_genesis::config::OperatorConfiguration;
+use diem_types::account_address::AccountAddress;
 use libra_types::global_config_dir;
 use libra_wallet::validator_files::OPERATOR_FILE;
-use std::fs;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 /// Public data structure for validators to register their nodes on chain
 /// creating this depends on access to private keys.
 ///
 // TODO: this matches the  libra framework sdk ValidatorUniverseRegisterValidator, there may be other duplications elsewhere.
-pub struct ValRegistrationPublic {
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ValCredentials {
+    pub account: AccountAddress,
     /// key for signing consensus transactions
     pub consensus_pubkey: Vec<u8>,
     /// proof that the node is in possession of the keys
@@ -20,7 +27,11 @@ pub struct ValRegistrationPublic {
     pub fullnode_addresses: Vec<u8>,
 }
 
-pub fn registration_from_file(operator_keyfile: Option<PathBuf>) -> anyhow::Result<ValRegistrationPublic> {
+/// given the operators private keys file at operator.yaml (usually)
+/// create the data structure needed for a registration transaction
+pub fn registration_from_private_file(
+    operator_keyfile: Option<PathBuf>,
+) -> anyhow::Result<ValCredentials> {
     let file = operator_keyfile.to_owned().unwrap_or_else(|| {
         let a = global_config_dir();
         a.join(OPERATOR_FILE)
@@ -41,10 +52,49 @@ pub fn registration_from_file(operator_keyfile: Option<PathBuf>) -> anyhow::Resu
             .context("cannot find fullnode network public key in operator config file")?,
     )?;
 
-    Ok(ValRegistrationPublic {
+    Ok(ValCredentials {
+        account: oc.operator_account_address.into(),
         consensus_pubkey: oc.consensus_public_key.to_bytes().to_vec(),
         proof_of_possession: oc.consensus_proof_of_possession.to_bytes().to_vec(),
         network_addresses: bcs::to_bytes(&vec![val_net_protocol])?,
         fullnode_addresses: bcs::to_bytes(&vec![vfn_fullnode_protocol])?,
     })
+}
+
+pub fn registration_to_file(reg: ValCredentials, out: &Path) -> anyhow::Result<()> {
+    let yaml_str = serde_yaml::to_string(&reg)?;
+    fs::write(out, yaml_str.into_bytes())?;
+    Ok(())
+}
+
+/// given a list of public validator registrations,
+/// create the list of validators that need to be created on chain
+/// NOTE: this is for testnet purposes.
+pub fn parse_pub_files_to_vec(files: Vec<PathBuf>) -> Vec<ValCredentials> {
+    files
+        .iter()
+        .map(|p| {
+            println!("reading file: {}", p.display());
+            let s = fs::read_to_string(p).expect("could not read registration file");
+            let vr: ValCredentials = serde_yaml::from_str(&s).expect("could not parse file");
+            vr
+        })
+        .collect()
+}
+
+#[test]
+
+fn test_registration_pub_file_output() {
+    use diem_temppath::TempPath;
+
+    let vr = ValCredentials {
+        account: AccountAddress::ZERO,
+        consensus_pubkey: vec![],
+        proof_of_possession: vec![],
+        network_addresses: vec![],
+        fullnode_addresses: vec![],
+    };
+    let file = TempPath::new();
+    file.create_as_file().unwrap();
+    registration_to_file(vr, file.path()).unwrap();
 }

--- a/tools/rescue/src/rescue_tx.rs
+++ b/tools/rescue/src/rescue_tx.rs
@@ -4,7 +4,7 @@ use diem_types::{
     account_address::AccountAddress,
     transaction::{Script, Transaction, WriteSetPayload},
 };
-use libra_config::validator_registration::{parse_pub_files_to_vec, ValCredentials};
+use libra_config::validator_registration::parse_pub_files_to_vec;
 use libra_framework::builder::framework_generate_upgrade_proposal::libra_compile_script;
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use std::path::PathBuf;

--- a/tools/rescue/src/rescue_tx.rs
+++ b/tools/rescue/src/rescue_tx.rs
@@ -4,6 +4,7 @@ use diem_types::{
     account_address::AccountAddress,
     transaction::{Script, Transaction, WriteSetPayload},
 };
+use libra_config::validator_registration::{parse_pub_files_to_vec, ValCredentials};
 use libra_framework::builder::framework_generate_upgrade_proposal::libra_compile_script;
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use std::path::PathBuf;
@@ -27,6 +28,11 @@ pub struct RescueTxOpts {
     /// Replace validator set with these addresses. They must
     /// already have valid configurations on chain.
     pub debug_vals: Option<Vec<AccountAddress>>,
+    // TODO
+    /// testnet twin options
+    /// replaces the validator set with these new validators that need to be registered
+    /// must be in format of testnet_vals.yaml
+    pub testnet_vals: Option<Vec<PathBuf>>,
 }
 
 impl RescueTxOpts {
@@ -51,6 +57,10 @@ impl RescueTxOpts {
         } else if self.framework_upgrade {
             let cs =
                 session_tools::publish_current_framework(&db_path, self.debug_vals.to_owned())?;
+            Transaction::GenesisTransaction(WriteSetPayload::Direct(cs))
+        } else if let Some(reg_files) = self.testnet_vals.to_owned() {
+            let registrations = parse_pub_files_to_vec(reg_files);
+            let cs = session_tools::twin_testnet(&db_path, registrations)?;
             Transaction::GenesisTransaction(WriteSetPayload::Direct(cs))
         } else {
             anyhow::bail!("no options provided, need a --framework-upgrade or a --script-path");
@@ -90,6 +100,7 @@ fn test_create_blob() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     r.run()?;
 

--- a/tools/rescue/src/session_tools.rs
+++ b/tools/rescue/src/session_tools.rs
@@ -287,14 +287,16 @@ fn combined_steps(session: &mut SessionExt) -> anyhow::Result<()> {
 }
 
 /// Twin testnet registration, replace validator set with new registrations
-pub fn twin_testnet(
-    dir: &Path,
-    testnet_vals: Vec<ValCredentials>,
-) -> anyhow::Result<ChangeSet> {
-    let vmc = libra_run_session(dir.to_path_buf(), |session| {
-      // if we are doing a twin testnet we don't want to upgrade the chain
-      session_add_validators(session, testnet_vals, false)
-    }, None, None)?;
+pub fn twin_testnet(dir: &Path, testnet_vals: Vec<ValCredentials>) -> anyhow::Result<ChangeSet> {
+    let vmc = libra_run_session(
+        dir.to_path_buf(),
+        |session| {
+            // if we are doing a twin testnet we don't want to upgrade the chain
+            session_add_validators(session, testnet_vals, false)
+        },
+        None,
+        None,
+    )?;
     unpack_changeset(vmc)
 }
 

--- a/tools/rescue/src/twin.rs
+++ b/tools/rescue/src/twin.rs
@@ -277,8 +277,7 @@ impl TwinSetup for Twin {
         // 4. Create a rescue blob with the new validator
         println!("3. Create a rescue blob with the new validator");
         let first_val = smoke.swarm.validators().next().unwrap().peer_id();
-        let genesis_blob_path =
-            Self::make_rescue_twin_blob(&swarm_db_paths[0], creds).await?;
+        let genesis_blob_path = Self::make_rescue_twin_blob(&swarm_db_paths[0], creds).await?;
         let mut genesis_blob_paths = Vec::new();
         genesis_blob_paths.push(genesis_blob_path.clone());
         // 4. Apply the rescue blob to the swarm db

--- a/tools/rescue/src/twin.rs
+++ b/tools/rescue/src/twin.rs
@@ -31,6 +31,7 @@ use std::{
 };
 use tokio::process::Command;
 
+use libra_config::validator_registration::ValCredentials;
 use libra_txs::txs_cli::{TxsCli, TxsSub::Transfer};
 use libra_types::core_types::app_cfg::TxCost;
 
@@ -38,7 +39,6 @@ use crate::{
     rescue_tx::RescueTxOpts,
     session_tools::{
         self, libra_execute_session_function, libra_run_session, writeset_voodoo_events,
-        ValCredentials,
     },
 };
 use diem_api_types::ViewRequest;
@@ -140,7 +140,7 @@ pub trait TwinSetup {
     fn recue_blob_with_one_val();
     async fn make_rescue_twin_blob(
         db_path: &Path,
-        creds: Vec<&ValCredentials>,
+        creds: Vec<ValCredentials>,
     ) -> anyhow::Result<PathBuf>;
     fn update_node_config_restart(
         validator: &mut LocalNode,
@@ -191,13 +191,13 @@ impl TwinSetup for Twin {
     /// '''
     async fn make_rescue_twin_blob(
         db_path: &Path,
-        creds: Vec<&ValCredentials>,
+        creds: Vec<ValCredentials>,
     ) -> anyhow::Result<PathBuf> {
         println!("run session to create validator onboarding tx (rescue.blob)");
         let epoch_interval = 100000_u64;
         let vmc = libra_run_session(
             db_path.to_path_buf(),
-            |session| session_add_validators(session, creds),
+            |session| session_add_validators(session, creds, true),
             None,
             None,
         )?;
@@ -253,7 +253,7 @@ impl TwinSetup for Twin {
             creds.push(cred);
         }
         //convert from Vec<ValCredentials> to Vec<&ValCredentials>
-        let creds = creds.iter().collect::<Vec<_>>();
+        let creds = creds.into_iter().collect::<Vec<_>>();
 
         // 2.Replace the swarm db with the brick db
         println!("2.Replace the swarm db with the brick db");
@@ -278,7 +278,7 @@ impl TwinSetup for Twin {
         println!("3. Create a rescue blob with the new validator");
         let first_val = smoke.swarm.validators().next().unwrap().peer_id();
         let genesis_blob_path =
-            Self::make_rescue_twin_blob(&swarm_db_paths[0], creds.to_owned()).await?;
+            Self::make_rescue_twin_blob(&swarm_db_paths[0], creds).await?;
         let mut genesis_blob_paths = Vec::new();
         genesis_blob_paths.push(genesis_blob_path.clone());
         // 4. Apply the rescue blob to the swarm db

--- a/tools/rescue/tests/rescue_cli_creates_blob.rs
+++ b/tools/rescue/tests/rescue_cli_creates_blob.rs
@@ -41,6 +41,7 @@ async fn test_valid_genesis() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     r.run()?;
 
@@ -115,6 +116,7 @@ async fn test_can_build_gov_rescue_script() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     r.run()?;
 
@@ -162,6 +164,7 @@ async fn test_valid_waypoint() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     r.run()?;
 

--- a/tools/rescue/tests/rescue_cli_framework_upgrade_valid.rs
+++ b/tools/rescue/tests/rescue_cli_framework_upgrade_valid.rs
@@ -29,6 +29,7 @@ async fn test_framework_upgrade_writeset() -> anyhow::Result<()> {
         script_path: None,
         framework_upgrade: true,
         debug_vals: None,
+        testnet_vals: None,
     };
     r.run()?;
 

--- a/tools/rescue/tests/rescue_e2e_can_create_genesis.rs
+++ b/tools/rescue/tests/rescue_e2e_can_create_genesis.rs
@@ -66,6 +66,7 @@ async fn test_create_e2e_rescue_tx() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     let genesis_blob_path = rescue.run()?;
 

--- a/tools/rescue/tests/rescue_e2e_can_restart.rs
+++ b/tools/rescue/tests/rescue_e2e_can_restart.rs
@@ -66,6 +66,7 @@ async fn test_can_restart() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     let genesis_blob_path = rescue.run().unwrap();
 

--- a/tools/rescue/tests/rescue_e2e_full.rs
+++ b/tools/rescue/tests/rescue_e2e_full.rs
@@ -70,6 +70,7 @@ async fn test_rescue_e2e_with_sync() -> anyhow::Result<()> {
         script_path: Some(script_path),
         framework_upgrade: false,
         debug_vals: None,
+        testnet_vals: None,
     };
     let genesis_blob_path = rescue.run().unwrap();
 

--- a/tools/rescue/tests/twin.rs
+++ b/tools/rescue/tests/twin.rs
@@ -62,6 +62,7 @@ async fn test_twin() -> anyhow::Result<()> {
         script_path: None,
         framework_upgrade: true,
         debug_vals: Some(vec![first_validator_address]),
+        testnet_vals: None,
     };
     r.run()?;
 

--- a/tools/txs/Cargo.toml
+++ b/tools/txs/Cargo.toml
@@ -23,6 +23,7 @@ diem-types = { workspace = true }
 hex = { workspace = true }
 indoc = { workspace = true }
 libra-cached-packages = { workspace = true }
+libra-config = { workspace = true }
 libra-query = { workspace = true }
 libra-types = { workspace = true }
 libra-wallet = { workspace = true }

--- a/tools/txs/src/txs_cli_vals.rs
+++ b/tools/txs/src/txs_cli_vals.rs
@@ -107,7 +107,9 @@ impl ValidatorTxs {
                 }
             }
             ValidatorTxs::Register { operator_file } => {
-                let reg = validator_registration::registration_from_private_file(operator_file.to_owned())?;
+                let reg = validator_registration::registration_from_private_file(
+                    operator_file.to_owned(),
+                )?;
                 ValidatorUniverseRegisterValidator {
                     consensus_pubkey: reg.consensus_pubkey,
                     proof_of_possession: reg.proof_of_possession,


### PR DESCRIPTION
- [x] refactor libra_config to generate public ValCredentials
- [x] export ValCredentials to file
- [x] rescue can receive a list of files, which get parsed as ValCredentials
- [x] rescue cli has option for testnet