### PR TITLE
[ci] build_env action should call main get_cli action

### DIFF
--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -42,4 +42,4 @@ runs:
 
     # call own action for libra_cli
     # TODO: figure out how to get the local action of this commit
-    - uses: 0LNetworkCommunity/libra-framework/.github/actions/get_cli
+    - uses: 0LNetworkCommunity/libra-framework/.github/actions/get_cli@main

--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -41,4 +41,5 @@ runs:
         cache-on-failure: "true"
 
     # call own action for libra_cli
-    - uses: 0LNetworkCommunity/libra-framework/.github/actions/get_cli@ci
+    # TODO: figure out how to get the local action of this commit
+    - uses: 0LNetworkCommunity/libra-framework/.github/actions/get_cli


### PR DESCRIPTION
NOTE: in the future the get_cli should likely come from the same git ref as the commit.