### PR TITLE
[deps] update diem to version with feature flag cleanup

### DIFF
--- a/.github/workflows/nuke-ci.yaml
+++ b/.github/workflows/nuke-ci.yaml
@@ -1,8 +1,7 @@
 name: nuke the CI
 on:
-  push:
-    tags:
-      - "nuke-ci*"
+  workflow_dispatch:
+
 jobs:
   delete_all_runs:
     name: delete all workflow runs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,7 @@ on:
       - "ci-bins*"
     tags: # run this also on release candidates
       - "[0-9]+.[0-9]+.[0-9]*"
-      # make binaries which may be ahead of releases to use in CI jobs
-      - "ci-bins"
+
 jobs:
   publish:
     permissions:
@@ -32,11 +31,24 @@ jobs:
         # size and performance optimized binary with profile.cli
         run: cargo b --release -p libra
 
+      # release bin
       - name: libra publish
+        if: ${{ !contains(github.ref, 'ci-bins') }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/release/libra
           tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+
+      # CI bin
+      - name: libra publish
+        if: ${{ contains(github.ref, 'ci-bins') }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/release/libra
+          tag: ci-bins
           overwrite: true
           file_glob: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,9 @@
 name: publish cli
 on:
   push:
+    branches:
+      # make binaries which may be ahead of releases to use in CI jobs
+      - "ci-bins*"
     tags: # run this also on release candidates
       - "[0-9]+.[0-9]+.[0-9]*"
       # make binaries which may be ahead of releases to use in CI jobs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -285,7 +285,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.19",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -321,7 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -352,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609c78bd572f4edc74310dfb63a01f5609d53fa8b4dd7c4d98aef3b3e8d72d1"
 dependencies = [
  "proc-macro-hack",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -401,19 +401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.208",
+ "serde 1.0.209",
  "sync_wrapper",
  "tower",
  "tower-layer",
@@ -528,7 +528,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
@@ -538,7 +538,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
@@ -558,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -573,7 +573,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -599,11 +599,11 @@ dependencies = [
  "peeking_take_while",
  "prettyplease",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
  "regex-automata 0.4.7",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -738,9 +738,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 
 [[package]]
 name = "byteorder"
@@ -793,9 +793,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
 dependencies = [
  "jobserver",
  "libc",
@@ -833,7 +833,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.19",
- "serde 1.0.208",
+ "serde 1.0.209",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.13",
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -952,11 +952,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.20"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aedc27e53da9ff495f5da6f4325390e71f46f886022b618303042e8ccf4bcac"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -980,8 +980,8 @@ checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "termcolor",
  "unicode-width",
 ]
@@ -1053,7 +1053,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ dependencies = [
  "lazy_static 1.5.0",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -1107,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-xid 0.2.5",
 ]
 
@@ -1151,7 +1151,7 @@ dependencies = [
  "idna 0.2.3",
  "log",
  "publicsuffix",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_derive",
  "serde_json",
  "time",
@@ -1335,7 +1335,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1412,9 +1412,9 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -1435,8 +1435,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1454,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1516,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -1532,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -1543,8 +1543,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1555,9 +1555,9 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustc_version",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1581,14 +1581,14 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
  "codespan-reporting",
  "diem-api-types",
@@ -1646,7 +1646,7 @@ dependencies = [
  "regex",
  "reqwest",
  "self_update",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "shadow-rs",
@@ -1654,7 +1654,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "toml 0.5.11",
  "walkdir",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1672,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1722,7 +1722,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "tokio",
  "url",
@@ -1731,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1751,20 +1751,20 @@ dependencies = [
  "move-resource-viewer",
  "poem",
  "poem-openapi",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
  "bytes",
- "clap 4.5.16",
+ "clap 4.5.17",
  "csv",
  "diem-backup-service",
  "diem-config",
@@ -1793,19 +1793,19 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
  "tokio-io-timeout",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1819,7 +1819,7 @@ dependencies = [
  "diem-types",
  "hyper",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
  "warp",
 ]
@@ -1827,16 +1827,16 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
 ]
 
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1861,11 +1861,11 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dashmap 5.5.3",
  "diem-crypto",
  "diem-logger",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "futures",
  "tokio",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "shadow-rs",
 ]
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1923,17 +1923,17 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anstyle",
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
 ]
 
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1965,7 +1965,7 @@ dependencies = [
  "num_cpus",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_merge",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2026,7 +2026,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2037,14 +2037,14 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-crypto",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
 ]
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2068,26 +2068,26 @@ dependencies = [
  "mirai-annotations",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
 ]
 
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "backtrace",
  "diem-logger",
  "move-core-types",
- "serde 1.0.208",
+ "serde 1.0.209",
  "toml 0.5.11",
 ]
 
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2110,7 +2110,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring 0.16.20",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde-name",
  "serde_bytes",
  "sha2 0.10.8",
@@ -2124,17 +2124,17 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2153,7 +2153,7 @@ dependencies = [
  "futures",
  "itertools",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
 ]
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2178,7 +2178,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2195,7 +2195,7 @@ dependencies = [
  "bcs 0.1.4",
  "byteorder",
  "claims",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dashmap 5.5.3",
  "diem-accumulator",
  "diem-config",
@@ -2226,7 +2226,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "static_assertions",
  "status-line",
  "thiserror",
@@ -2235,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2255,17 +2255,17 @@ dependencies = [
  "move-core-types",
  "move-resource-viewer",
  "num-derive",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-backup-cli",
  "diem-backup-service",
  "diem-config",
@@ -2285,10 +2285,10 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-crypto",
  "diem-gas",
  "diem-gas-profiling",
@@ -2316,17 +2316,17 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2336,14 +2336,14 @@ dependencies = [
  "diem-storage-interface",
  "diem-types",
  "futures",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2368,13 +2368,13 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2412,14 +2412,14 @@ dependencies = [
  "diem-types",
  "itertools",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "thiserror",
 ]
@@ -2427,12 +2427,12 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "captcha",
- "clap 4.5.16",
+ "clap 4.5.17",
  "deadpool-redis",
  "diem-config",
  "diem-faucet-metrics-server",
@@ -2451,7 +2451,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2469,20 +2469,20 @@ dependencies = [
  "once_cell",
  "poem",
  "prometheus",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem",
  "diem-cached-packages",
  "diem-cli-common",
@@ -2518,7 +2518,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2544,7 +2544,7 @@ dependencies = [
  "better_any",
  "blake2-rfc",
  "blst",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan-reporting",
  "curve25519-dalek",
  "diem-aggregator",
@@ -2579,7 +2579,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rayon",
  "ripemd",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2596,11 +2596,11 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-framework",
  "diem-gas-algebra-ext",
  "diem-global-constants",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "move-core-types",
 ]
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2664,17 +2664,17 @@ dependencies = [
  "diem-vm",
  "diem-vm-genesis",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_yaml 0.8.26",
 ]
 
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-proxy",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
  "ureq",
@@ -2683,24 +2683,24 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-api",
  "diem-api-types",
  "diem-bitvec",
@@ -2722,7 +2722,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "sha2 0.9.9",
  "tokio",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2759,7 +2759,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -2769,12 +2769,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2816,14 +2816,14 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2865,23 +2865,23 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2893,7 +2893,7 @@ dependencies = [
  "hostname",
  "once_cell",
  "prometheus",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "strum",
  "strum_macros",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2935,7 +2935,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2945,13 +2945,13 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
 ]
@@ -2959,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "chrono",
 ]
@@ -3010,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3033,16 +3033,16 @@ dependencies = [
  "diem-types",
  "futures",
  "pin-project",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "url",
 ]
 
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3073,19 +3073,19 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3104,31 +3104,31 @@ dependencies = [
  "futures",
  "maplit",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-config",
  "diem-crypto",
  "diem-logger",
  "diem-network",
  "diem-types",
  "futures",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3154,11 +3154,11 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-api",
  "diem-backup-service",
  "diem-build-info",
@@ -3208,7 +3208,7 @@ dependencies = [
  "maplit",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "claims",
@@ -3231,30 +3231,30 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "percent-encoding",
  "poem",
  "poem-openapi",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3284,7 +3284,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3312,7 +3312,7 @@ dependencies = [
  "diem-types",
  "futures",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
 ]
@@ -3320,20 +3320,20 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
  "diem-config",
  "diem-types",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3343,18 +3343,18 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "pbjson",
  "prost",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tonic",
 ]
 
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "ipnet",
 ]
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3381,17 +3381,17 @@ dependencies = [
  "futures",
  "pin-project",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
 ]
 
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem",
  "diem-api-types",
  "diem-build-info",
@@ -3411,7 +3411,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3451,7 +3451,7 @@ dependencies = [
  "move-core-types",
  "poem-openapi",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3461,7 +3461,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3479,11 +3479,11 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-cached-packages",
  "diem-config",
  "diem-crypto",
@@ -3502,7 +3502,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "tokio",
 ]
@@ -3521,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3537,7 +3537,7 @@ dependencies = [
  "diem-vault-client",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
 ]
@@ -3545,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3576,7 +3576,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3589,18 +3589,18 @@ dependencies = [
  "ed25519-dalek-bip32",
  "move-core-types",
  "rand_core 0.5.1",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-types",
  "heck 0.3.3",
  "move-core-types",
@@ -3615,19 +3615,19 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3641,7 +3641,7 @@ dependencies = [
  "diem-vault-client",
  "enum_dispatch",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
 ]
@@ -3649,10 +3649,10 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "mirai-annotations",
- "serde 1.0.208",
+ "serde 1.0.209",
  "static_assertions",
  "thiserror",
 ]
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3698,7 +3698,7 @@ dependencies = [
  "futures",
  "once_cell",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3707,13 +3707,13 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "diem-crypto",
  "diem-types",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "serde_json",
 ]
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3741,14 +3741,14 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3780,7 +3780,7 @@ dependencies = [
  "futures",
  "lru 0.7.8",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
  "tokio",
 ]
@@ -3788,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3796,14 +3796,14 @@ dependencies = [
  "diem-crypto",
  "diem-types",
  "num-traits 0.2.19",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3812,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3825,12 +3825,12 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem",
  "diem-config",
  "diem-crypto",
@@ -3848,7 +3848,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
  "url",
 ]
@@ -3856,12 +3856,12 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem",
  "diem-config",
  "diem-crypto",
@@ -3878,7 +3878,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "tokio",
  "url",
 ]
@@ -3886,11 +3886,11 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-api-types",
  "diem-cached-packages",
  "diem-crypto",
@@ -3911,14 +3911,14 @@ dependencies = [
  "move-transactional-test-runner",
  "move-vm-runtime",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3940,7 +3940,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3951,12 +3951,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3977,14 +3977,14 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "base64 0.13.1",
  "chrono",
  "diem-crypto",
  "native-tls",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
  "ureq",
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4031,7 +4031,7 @@ dependencies = [
  "ouroboros 0.15.6",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "smallvec",
  "tracing",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4055,13 +4055,13 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4071,13 +4071,13 @@ dependencies = [
  "diem-state-view",
  "diem-types",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4113,16 +4113,16 @@ dependencies = [
  "diem-config",
  "diem-logger",
  "hyper",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "warp",
 ]
 
 [[package]]
 name = "diesel"
-version = "2.2.2"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
+checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
 dependencies = [
  "bigdecimal",
  "bitflags 2.6.0",
@@ -4140,15 +4140,15 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ff2be1e7312c858b2ef974f5c7089833ae57b5311b334b30923af58e5718d8"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4168,7 +4168,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4257,8 +4257,8 @@ dependencies = [
  "either",
  "heck 0.5.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4267,7 +4267,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "signature",
 ]
 
@@ -4280,7 +4280,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -4327,8 +4327,8 @@ checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4362,7 +4362,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -4405,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
@@ -4433,7 +4433,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1320970ff3b1c1cacc6a38e8cdb1aced955f29627697cd992c5ded82eb646a8"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -4463,9 +4463,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -4568,7 +4568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -4764,10 +4764,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tracing",
 ]
 
@@ -4780,7 +4780,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
 ]
@@ -4881,7 +4881,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -5191,7 +5191,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -5201,7 +5201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -5235,7 +5235,7 @@ dependencies = [
  "anyhow",
  "proc-macro-hack",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -5246,7 +5246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
 ]
 
 [[package]]
@@ -5257,18 +5257,18 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -5297,12 +5297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.11",
- "clap 4.5.16",
+ "clap 4.5.17",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap 6.0.1",
+ "dashmap 6.1.0",
  "env_logger",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "is-terminal",
  "itoa",
  "log",
@@ -5445,7 +5445,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "treediff",
 ]
@@ -5457,7 +5457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
 dependencies = [
  "log",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
 ]
 
@@ -5470,7 +5470,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde-value",
  "serde_json",
 ]
@@ -5519,7 +5519,7 @@ dependencies = [
  "pin-project",
  "rustls 0.20.9",
  "rustls-pemfile 0.2.1",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -5542,7 +5542,7 @@ dependencies = [
  "json-patch",
  "k8s-openapi",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
 ]
@@ -5619,7 +5619,7 @@ name = "libra"
 version = "7.0.3"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem",
  "diem-config",
  "diem-node",
@@ -5654,7 +5654,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem",
  "diem-config",
@@ -5666,7 +5666,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -5679,7 +5679,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem",
  "diem-build-info",
@@ -5701,7 +5701,7 @@ dependencies = [
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem-config",
  "diem-crypto",
@@ -5724,7 +5724,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "move-core-types",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "tokio",
  "ureq",
@@ -5735,7 +5735,7 @@ name = "libra-query"
 version = "7.0.3"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-api-types",
  "diem-debugger",
  "diem-sdk",
@@ -5754,7 +5754,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-api-types",
  "diem-config",
  "diem-crypto",
@@ -5810,7 +5810,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "diem-backup-cli",
  "diem-config",
  "diem-db",
@@ -5833,7 +5833,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem-api-types",
  "diem-config",
@@ -5862,7 +5862,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem",
  "diem-forge",
@@ -5881,7 +5881,7 @@ dependencies = [
  "libra-smoke-tests",
  "libra-types",
  "libra-wallet",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "smoke-test",
@@ -5896,7 +5896,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "console",
  "diem",
  "diem-api-types",
@@ -5915,7 +5915,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -5950,7 +5950,7 @@ dependencies = [
  "anyhow",
  "blst",
  "byteorder",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dialoguer",
  "diem-config",
  "diem-crypto",
@@ -5965,7 +5965,7 @@ dependencies = [
  "pbkdf2 0.7.5",
  "rand 0.7.3",
  "rpassword",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
@@ -6012,7 +6012,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.208",
+ "serde 1.0.209",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -6073,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -6107,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "lodepng"
-version = "3.10.5"
+version = "3.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7912e09a5b971ceb60f87e97ca07055986269b2a35e0b7b43734a5f7680adb1f"
+checksum = "7b2dea7cda68e381418c985fd8f32a9c279a21ae8c715f2376adb20c27a0fad3"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -6123,7 +6123,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -6209,7 +6209,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "toml 0.8.2",
 ]
 
@@ -6221,7 +6221,7 @@ checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
 ]
 
 [[package]]
@@ -6292,7 +6292,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6303,13 +6303,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6319,19 +6319,19 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "ref-cast",
- "serde 1.0.208",
+ "serde 1.0.209",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6340,13 +6340,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6358,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6372,10 +6372,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "crossterm 0.26.1",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6389,11 +6389,11 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan-reporting",
  "colored",
  "difference",
@@ -6422,7 +6422,7 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "difference",
@@ -6442,7 +6442,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -6450,11 +6450,11 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan-reporting",
  "difference",
  "hex",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6493,7 +6493,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_bytes",
  "uint",
 ]
@@ -6501,11 +6501,11 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan",
  "colored",
  "move-binary-format",
@@ -6515,16 +6515,16 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6539,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6552,13 +6552,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6566,17 +6566,17 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -6591,7 +6591,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -6623,7 +6623,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -6631,13 +6631,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6657,18 +6657,18 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "trace",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "dirs-next",
  "itertools",
@@ -6688,7 +6688,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
@@ -6700,12 +6700,12 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -6727,7 +6727,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "simplelog",
  "tokio",
@@ -6737,7 +6737,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6757,7 +6757,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "tera",
  "tokio",
@@ -6766,7 +6766,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6775,13 +6775,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6801,13 +6801,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -6830,16 +6830,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6856,10 +6856,10 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6887,11 +6887,11 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "better_any",
- "clap 4.5.16",
+ "clap 4.5.17",
  "codespan-reporting",
  "colored",
  "itertools",
@@ -6917,7 +6917,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6934,7 +6934,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6942,19 +6942,19 @@ dependencies = [
  "move-table-extension",
  "move-vm-types",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "smallvec",
 ]
 
@@ -7100,7 +7100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7191,9 +7191,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -7232,8 +7232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7298,7 +7298,7 @@ dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7311,7 +7311,7 @@ dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7338,7 +7338,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7433,7 +7433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599fe9aefc2ca0df4a96179b3075faee2cacb89d4cf947a00b9a89152dfffc9d"
 dependencies = [
  "base64 0.13.1",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -7509,8 +7509,8 @@ dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7541,7 +7541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
 ]
 
 [[package]]
@@ -7598,8 +7598,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7658,7 +7658,7 @@ dependencies = [
  "regex",
  "rfc7239",
  "rustls-pemfile 1.0.4",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -7669,7 +7669,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tracing",
 ]
 
@@ -7681,8 +7681,8 @@ checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7701,7 +7701,7 @@ dependencies = [
  "poem-openapi-derive",
  "quick-xml 0.26.0",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -7722,7 +7722,7 @@ dependencies = [
  "mime",
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
  "syn 1.0.109",
  "thiserror",
@@ -7782,12 +7782,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2 1.0.86",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7830,7 +7830,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7842,7 +7842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "version_check",
 ]
 
@@ -7891,7 +7891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
 dependencies = [
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "time",
  "url",
@@ -7947,7 +7947,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7968,7 +7968,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.5",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde-value",
  "tint",
 ]
@@ -8014,7 +8014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -8028,9 +8028,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2 1.0.86",
 ]
@@ -8195,7 +8195,7 @@ dependencies = [
  "ryu",
  "sha1_smol",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "url",
 ]
 
@@ -8204,15 +8204,6 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -8253,8 +8244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8328,13 +8319,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8354,7 +8345,7 @@ dependencies = [
  "async-trait",
  "http",
  "reqwest",
- "serde 1.0.208",
+ "serde 1.0.209",
  "task-local-extensions",
  "thiserror",
 ]
@@ -8410,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f86ae463694029097b846d8f99fd5536740602ae00022c0c50c5600720b2f71"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -8502,18 +8493,18 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -8714,9 +8705,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -8731,7 +8722,7 @@ dependencies = [
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde-reflection 0.3.5",
  "serde_bytes",
  "serde_yaml 0.8.26",
@@ -8757,7 +8748,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
@@ -8767,7 +8758,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
@@ -8778,7 +8769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.208",
+ "serde 1.0.209",
  "thiserror",
 ]
 
@@ -8789,7 +8780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -8798,31 +8789,31 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -8831,7 +8822,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "thiserror",
 ]
@@ -8842,7 +8833,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -8854,7 +8845,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -8867,8 +8858,8 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
- "serde 1.0.208",
+ "indexmap 2.5.0",
+ "serde 1.0.209",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -8883,8 +8874,8 @@ checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8895,7 +8886,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.208",
+ "serde 1.0.209",
  "yaml-rust",
 ]
 
@@ -8905,10 +8896,10 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
- "serde 1.0.208",
+ "serde 1.0.209",
  "unsafe-libyaml",
 ]
 
@@ -9122,7 +9113,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#b9f01f9189978520c8dffa08c7b75f3ea2f5f545"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#f81b6978c06fa5f655383e2fe65767574d3993c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9255,7 +9246,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -9273,7 +9264,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -9302,18 +9293,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
@@ -9403,7 +9394,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "slug",
  "unic-segment",
@@ -9470,8 +9461,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9505,7 +9496,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde 1.0.208",
+ "serde 1.0.209",
  "time-core",
  "time-macros",
 ]
@@ -9614,8 +9605,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9673,9 +9664,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -9710,9 +9701,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9728,7 +9719,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -9737,7 +9728,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.20.2",
@@ -9749,7 +9740,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -9761,7 +9752,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -9770,7 +9761,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow",
 ]
@@ -9781,8 +9772,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.4.0",
- "serde 1.0.208",
+ "indexmap 2.5.0",
+ "serde 1.0.209",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -9816,7 +9807,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tower",
  "tower-layer",
  "tower-service",
@@ -9838,7 +9829,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9883,7 +9874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -9906,8 +9897,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9947,7 +9938,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.208",
+ "serde 1.0.209",
  "tracing-core",
 ]
 
@@ -9961,7 +9952,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -10252,7 +10243,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "url",
 ]
@@ -10266,7 +10257,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
  "percent-encoding",
- "serde 1.0.208",
+ "serde 1.0.209",
 ]
 
 [[package]]
@@ -10309,7 +10300,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -10391,14 +10382,14 @@ dependencies = [
  "pin-project",
  "rustls-pemfile 1.0.4",
  "scoped-tls",
- "serde 1.0.208",
+ "serde 1.0.209",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.12",
  "tower-service",
  "tracing",
 ]
@@ -10442,8 +10433,8 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -10465,7 +10456,7 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "wasm-bindgen-macro-support",
 ]
 
@@ -10476,8 +10467,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10538,11 +10529,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.3",
  "wasite",
  "web-sys",
 ]
@@ -10815,8 +10806,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10835,8 +10826,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.75",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/tools/cli/src/node_cli.rs
+++ b/tools/cli/src/node_cli.rs
@@ -14,12 +14,15 @@ pub struct NodeCli {
 
 impl NodeCli {
     pub fn run(&self) -> anyhow::Result<()> {
-        // Production code should never have been compiled with
-        // Test helpers in the MoveVm. This fuction is a safety check.
-        // Check that we are not including any Move test natives
-        diem_vm::natives::assert_no_test_natives(
-            "SCARY: somehow your production binaries ended up with testing features. Aborting!",
-        );
+        // Commit Note: we can now remove the diem checks since we do actually
+        // expect the crypto test natives to exist in release compilations.
+        // but we still check to not expect compilation using --testing feature
+        // and also a unit test helper for creating signers
+        // TODO: A similar check can be done to check if unit_test natives have been built in VM. Though in libra they are unused.
+
+        // assert_no_test_natives(
+        //     "SCARY: somehow your production binaries ended up with testing features. Aborting!",
+        // );
 
         // validators typically aren't looking for verbose logs.
         // but they can set it if they wish with RUST_LOG=info


### PR DESCRIPTION
Now diem exposes some test functions to release builds (instead of testing feature flag), so the the CLI needs a minor update for `libra node` and the CI binaries can be updated. This change was the last needed for 7.0.3 binaries to be officially published.

- GitHub worfklow for releasing ci bins
- Updated cargo dependencies