### PR TITLE
Update tokio and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 dependencies = [
  "backtrace",
 ]
@@ -396,7 +396,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -597,7 +597,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a13ab5b8cb13dbe35e68b83f6c12f9293b2f601797b71bc9f23befdb329feb"
+checksum = "86bc73de94bc81e52f3bebec71bc4463e9748f7a59166663e32044669577b0e2"
 dependencies = [
  "clap 4.5.20",
 ]
@@ -975,7 +975,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1375,32 +1375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,7 +1419,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1467,7 +1441,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1581,7 +1555,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1594,7 +1568,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustc_version",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1618,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1699,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1709,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1727,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1768,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1795,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1842,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1864,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "serde 1.0.214",
  "serde_bytes",
@@ -1873,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1898,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1918,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "futures",
  "tokio",
@@ -1927,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "shadow-rs",
 ]
@@ -1935,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1948,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1960,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anstyle",
  "clap 4.5.20",
@@ -1970,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1982,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2012,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2074,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-crypto",
@@ -2089,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2112,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "backtrace",
  "diem-logger",
@@ -2124,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2133,7 +2107,7 @@ dependencies = [
  "bcs 0.1.4",
  "blst",
  "bytes",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "diem-crypto-derive",
  "digest 0.9.0",
  "ed25519-dalek",
@@ -2161,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2171,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2198,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2224,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2272,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2298,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2322,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -2353,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2363,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2380,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2411,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2435,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2456,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "thiserror",
 ]
@@ -2464,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2498,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2513,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "again",
  "anyhow",
@@ -2568,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2583,7 +2557,7 @@ dependencies = [
  "blst",
  "clap 4.5.20",
  "codespan-reporting",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "diem-aggregator",
  "diem-crypto",
  "diem-gas-algebra-ext",
@@ -2633,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2656,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "move-core-types",
 ]
@@ -2664,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2682,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2708,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-proxy",
  "serde 1.0.214",
@@ -2720,17 +2694,17 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2769,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2806,12 +2780,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2834,7 +2808,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2860,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2870,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2908,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2918,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2942,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2982,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-runtimes",
@@ -2996,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -3007,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -3016,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "hex",
@@ -3039,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "chrono",
 ]
@@ -3047,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3062,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3079,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3122,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3148,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3165,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3191,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3256,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "claims",
@@ -3268,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -3278,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -3291,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3304,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3330,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3357,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
@@ -3370,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3380,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "pbjson",
  "prost",
@@ -3391,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "ipnet",
 ]
@@ -3399,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3410,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3424,7 +3398,7 @@ dependencies = [
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3460,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3472,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3498,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3507,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3516,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3550,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "tokio",
 ]
@@ -3558,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3582,7 +3556,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3596,7 +3570,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3613,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3633,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3652,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3664,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3686,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "mirai-annotations",
  "serde 1.0.214",
@@ -3697,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3709,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3744,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3758,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3785,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3799,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3825,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3840,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3849,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3862,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "again",
  "anyhow",
@@ -3893,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "again",
  "anyhow",
@@ -3923,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3955,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3988,12 +3962,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4014,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -4030,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4077,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4098,7 +4072,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4114,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4127,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4142,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4185,7 +4159,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4205,7 +4179,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4295,7 +4269,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4314,7 +4288,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.2.0",
+ "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde 1.0.214",
@@ -4365,7 +4339,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4454,12 +4428,6 @@ checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
 dependencies = [
  "simd-adler32",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field_count"
@@ -4621,7 +4589,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6512,7 +6480,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6529,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6546,12 +6514,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6566,7 +6534,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6578,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6592,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6609,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6653,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "difference",
@@ -6670,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6699,7 +6667,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6721,7 +6689,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6741,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6759,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6778,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6792,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6811,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6830,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "hex",
@@ -6843,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "hex",
@@ -6857,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6884,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6920,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6957,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7001,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7027,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "hex",
@@ -7050,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "once_cell",
  "serde 1.0.214",
@@ -7059,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7076,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -7107,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7137,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7154,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7168,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
@@ -7453,7 +7421,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7732,7 +7700,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7821,7 +7789,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7904,7 +7872,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8009,7 +7977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2 1.0.89",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8467,7 +8435,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -9105,7 +9073,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -9180,7 +9148,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -9418,7 +9386,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9604,9 +9572,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -9752,22 +9720,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -9908,7 +9876,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -10224,7 +10192,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -10756,7 +10724,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-shared",
 ]
 
@@ -10790,7 +10758,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11087,13 +11055,11 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+version = "1.2.0"
+source = "git+https://github.com/0LNetworkCommunity/x25519-dalek?branch=zeroize_v1#762a9501668d213daa4a1864fa1f9db22716b661"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde 1.0.214",
+ "curve25519-dalek",
+ "rand_core 0.5.1",
  "zeroize",
 ]
 
@@ -11130,7 +11096,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -11150,7 +11116,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -597,7 +597,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -787,9 +787,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
 dependencies = [
  "jobserver",
  "libc",
@@ -975,7 +975,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1419,7 +1419,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1555,7 +1555,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1568,7 +1568,7 @@ dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustc_version",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1769,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "serde 1.0.214",
  "serde_bytes",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "futures",
  "tokio",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "shadow-rs",
 ]
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1934,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anstyle",
  "clap 4.5.20",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2048,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-crypto",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "backtrace",
  "diem-logger",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -2327,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "thiserror",
 ]
@@ -2438,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2472,7 +2472,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "again",
  "anyhow",
@@ -2519,8 +2519,9 @@ dependencies = [
  "hyper 0.14.31",
  "hyper-tls",
  "itertools",
- "json-patch 0.2.7",
- "k8s-openapi 0.13.1",
+ "json-patch",
+ "jsonptr",
+ "k8s-openapi",
  "kube",
  "num_cpus",
  "once_cell",
@@ -2542,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2607,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2630,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "move-core-types",
 ]
@@ -2638,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2656,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2682,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-proxy",
  "serde 1.0.214",
@@ -2694,17 +2695,17 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2743,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2780,12 +2781,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2808,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2834,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2844,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2882,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2892,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2916,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2956,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-runtimes",
@@ -2970,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -2981,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2990,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "hex",
@@ -3013,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "chrono",
 ]
@@ -3021,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3036,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3053,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3096,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3122,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3139,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3165,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3230,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "claims",
@@ -3242,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -3252,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "percent-encoding",
@@ -3265,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3278,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3304,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3331,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
@@ -3344,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3354,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "pbjson",
  "prost",
@@ -3365,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "ipnet",
 ]
@@ -3373,7 +3374,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3384,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3398,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3434,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3446,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3472,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3481,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3490,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3524,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "tokio",
 ]
@@ -3532,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3556,7 +3557,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3570,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3587,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3607,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3626,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3638,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3660,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "mirai-annotations",
  "serde 1.0.214",
@@ -3671,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3683,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3718,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3732,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3759,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3773,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3799,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3814,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3823,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3836,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "again",
  "anyhow",
@@ -3867,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "again",
  "anyhow",
@@ -3897,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3929,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3962,12 +3963,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3988,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -4004,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4051,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4072,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4088,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4101,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4116,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4159,7 +4160,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4179,7 +4180,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4269,7 +4270,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4339,7 +4340,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4589,7 +4590,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5190,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
  "hyper 1.5.0",
  "hyper-util",
@@ -5590,17 +5591,6 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
-dependencies = [
- "serde 1.0.214",
- "serde_json",
- "treediff",
-]
-
-[[package]]
-name = "json-patch"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
@@ -5639,20 +5629,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8de9873b904e74b3533f77493731ee26742418077503683db44e1b3c54aa5c"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "chrono",
- "serde 1.0.214",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
@@ -5679,7 +5655,7 @@ version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
 dependencies = [
- "k8s-openapi 0.23.0",
+ "k8s-openapi",
  "kube-client",
  "kube-core",
 ]
@@ -5702,10 +5678,10 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-http-proxy",
  "hyper-rustls",
- "hyper-timeout 0.5.1",
+ "hyper-timeout 0.5.2",
  "hyper-util",
  "jsonpath-rust",
- "k8s-openapi 0.23.0",
+ "k8s-openapi",
  "kube-core",
  "pem",
  "rustls 0.23.16",
@@ -5731,8 +5707,8 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http 1.1.0",
- "json-patch 2.0.0",
- "k8s-openapi 0.23.0",
+ "json-patch",
+ "k8s-openapi",
  "serde 1.0.214",
  "serde-value",
  "serde_json",
@@ -6480,7 +6456,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6497,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6514,12 +6490,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6534,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6546,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6560,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6577,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6621,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "difference",
@@ -6638,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6667,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6689,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6709,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6727,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6746,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6760,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6779,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6798,7 +6774,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "hex",
@@ -6811,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "hex",
@@ -6825,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6852,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6888,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6925,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6954,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6969,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6995,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "hex",
@@ -7018,7 +6994,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "once_cell",
  "serde 1.0.214",
@@ -7027,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7044,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -7075,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7105,7 +7081,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7122,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7136,7 +7112,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
@@ -7421,7 +7397,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7700,7 +7676,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7789,7 +7765,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7872,7 +7848,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7977,7 +7953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2 1.0.89",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8435,7 +8411,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9073,7 +9049,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9148,7 +9124,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9386,7 +9362,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#955e936657000343797f9994bfe5434537140597"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#e402fe6d60b1fc0c2eecc51bc606c7200a579789"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9572,9 +9548,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.86"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -9720,22 +9696,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
+checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
+checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -9876,7 +9852,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -10192,7 +10168,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -10263,15 +10239,6 @@ version = "7.0.3"
 dependencies = [
  "datatest-stable",
  "diem-transactional-test-harness",
-]
-
-[[package]]
-name = "treediff"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
-dependencies = [
- "serde_json",
 ]
 
 [[package]]
@@ -10724,7 +10691,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -10758,7 +10725,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11096,7 +11063,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11116,7 +11083,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.86",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.213",
+ "serde 1.0.214",
  "sync_wrapper",
  "tower 0.4.13",
  "tower-layer",
@@ -522,7 +522,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
@@ -532,7 +532,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
@@ -567,7 +567,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
  "regex-automata 0.4.8",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.19",
- "serde 1.0.213",
+ "serde 1.0.214",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -1000,7 +1000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "termcolor",
  "unicode-width",
 ]
@@ -1059,7 +1059,7 @@ dependencies = [
  "lazy_static 1.5.0",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -1156,7 +1156,7 @@ dependencies = [
  "idna 0.3.0",
  "log",
  "publicsuffix",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_derive",
  "serde_json",
  "time",
@@ -1340,7 +1340,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1683,7 +1683,7 @@ dependencies = [
  "regex",
  "reqwest",
  "self_update",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "shadow-rs",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1759,7 +1759,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "tokio",
  "url",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1788,14 +1788,14 @@ dependencies = [
  "move-resource-viewer",
  "poem",
  "poem-openapi",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1830,7 +1830,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1856,7 +1856,7 @@ dependencies = [
  "diem-types",
  "hyper 0.14.31",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
  "warp",
 ]
@@ -1864,16 +1864,16 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
 ]
 
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "futures",
  "tokio",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "shadow-rs",
 ]
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1960,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anstyle",
  "clap 4.5.20",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2002,7 +2002,7 @@ dependencies = [
  "num_cpus",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_merge",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2063,7 +2063,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2074,14 +2074,14 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-crypto",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
 ]
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2105,26 +2105,26 @@ dependencies = [
  "mirai-annotations",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
 ]
 
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "backtrace",
  "diem-logger",
  "move-core-types",
- "serde 1.0.213",
+ "serde 1.0.214",
  "toml 0.5.11",
 ]
 
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2147,7 +2147,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring 0.16.20",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-name",
  "serde_bytes",
  "sha2 0.10.8",
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2190,7 +2190,7 @@ dependencies = [
  "futures",
  "itertools",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
 ]
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2215,7 +2215,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2263,7 +2263,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "static_assertions",
  "status-line",
  "thiserror",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2292,13 +2292,13 @@ dependencies = [
  "move-core-types",
  "move-resource-viewer",
  "num-derive",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -2353,7 +2353,7 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2373,14 +2373,14 @@ dependencies = [
  "diem-storage-interface",
  "diem-types",
  "futures",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2405,13 +2405,13 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2449,14 +2449,14 @@ dependencies = [
  "diem-types",
  "itertools",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "thiserror",
 ]
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2488,7 +2488,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2506,14 +2506,14 @@ dependencies = [
  "once_cell",
  "poem",
  "prometheus",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "again",
  "anyhow",
@@ -2555,7 +2555,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2616,7 +2616,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rayon",
  "ripemd",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "move-core-types",
 ]
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2682,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2701,17 +2701,17 @@ dependencies = [
  "diem-vm",
  "diem-vm-genesis",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_yaml 0.8.26",
 ]
 
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-proxy",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
  "ureq",
@@ -2720,17 +2720,17 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2759,7 +2759,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "sha2 0.9.9",
  "tokio",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2796,7 +2796,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -2806,12 +2806,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2853,14 +2853,14 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2870,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2902,13 +2902,13 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -2918,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2930,7 +2930,7 @@ dependencies = [
  "hostname",
  "once_cell",
  "prometheus",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "strum",
  "strum_macros",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2982,13 +2982,13 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
 ]
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "hex",
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "chrono",
 ]
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3070,7 +3070,7 @@ dependencies = [
  "diem-types",
  "futures",
  "pin-project",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
  "tokio-util",
  "url",
@@ -3079,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3110,7 +3110,7 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3141,14 +3141,14 @@ dependencies = [
  "futures",
  "maplit",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -3158,14 +3158,14 @@ dependencies = [
  "diem-network",
  "diem-types",
  "futures",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3245,7 +3245,7 @@ dependencies = [
  "maplit",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "claims",
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -3278,20 +3278,20 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "percent-encoding",
  "poem",
  "poem-openapi",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3321,7 +3321,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3349,7 +3349,7 @@ dependencies = [
  "diem-types",
  "futures",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
 ]
@@ -3357,20 +3357,20 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
  "diem-config",
  "diem-types",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3380,18 +3380,18 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "pbjson",
  "prost",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tonic",
 ]
 
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "ipnet",
 ]
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3448,7 +3448,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3488,7 +3488,7 @@ dependencies = [
  "move-core-types",
  "poem-openapi",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3539,7 +3539,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "tokio",
 ]
@@ -3558,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3574,7 +3574,7 @@ dependencies = [
  "diem-vault-client",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
 ]
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3613,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3626,14 +3626,14 @@ dependencies = [
  "ed25519-dalek-bip32",
  "move-core-types",
  "rand_core 0.5.1",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3652,19 +3652,19 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3678,7 +3678,7 @@ dependencies = [
  "diem-vault-client",
  "enum_dispatch",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
 ]
@@ -3686,10 +3686,10 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "mirai-annotations",
- "serde 1.0.213",
+ "serde 1.0.214",
  "static_assertions",
  "thiserror",
 ]
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3735,7 +3735,7 @@ dependencies = [
  "futures",
  "once_cell",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3744,13 +3744,13 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "diem-crypto",
  "diem-types",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "serde_json",
 ]
@@ -3758,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3778,14 +3778,14 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3817,7 +3817,7 @@ dependencies = [
  "futures",
  "lru 0.7.8",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
  "tokio",
 ]
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3833,14 +3833,14 @@ dependencies = [
  "diem-crypto",
  "diem-types",
  "num-traits 0.2.19",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3862,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "again",
  "anyhow",
@@ -3885,7 +3885,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
  "url",
 ]
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "again",
  "anyhow",
@@ -3915,7 +3915,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "tokio",
  "url",
 ]
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3948,14 +3948,14 @@ dependencies = [
  "move-transactional-test-runner",
  "move-vm-runtime",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3977,7 +3977,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3988,12 +3988,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4014,14 +4014,14 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "base64 0.13.1",
  "chrono",
  "diem-crypto",
  "native-tls",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
  "ureq",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4068,7 +4068,7 @@ dependencies = [
  "ouroboros 0.15.6",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "smallvec",
  "tracing",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4092,13 +4092,13 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4108,13 +4108,13 @@ dependencies = [
  "diem-state-view",
  "diem-types",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4150,7 +4150,7 @@ dependencies = [
  "diem-config",
  "diem-logger",
  "hyper 0.14.31",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "warp",
 ]
@@ -4304,7 +4304,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "signature",
 ]
 
@@ -4317,7 +4317,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -4399,7 +4399,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -4830,7 +4830,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
 ]
@@ -4961,7 +4961,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -5372,7 +5372,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -5438,7 +5438,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -5449,7 +5449,7 @@ checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -5626,7 +5626,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "treediff",
 ]
@@ -5638,7 +5638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
  "jsonptr",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
 ]
@@ -5665,7 +5665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
 dependencies = [
  "fluent-uri",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
 ]
 
@@ -5678,7 +5678,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-value",
  "serde_json",
 ]
@@ -5691,7 +5691,7 @@ checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-value",
  "serde_json",
 ]
@@ -5743,7 +5743,7 @@ dependencies = [
  "rustls 0.23.16",
  "rustls-pemfile 2.2.0",
  "secrecy",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "thiserror",
@@ -5765,7 +5765,7 @@ dependencies = [
  "http 1.1.0",
  "json-patch 2.0.0",
  "k8s-openapi 0.23.0",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-value",
  "serde_json",
  "thiserror",
@@ -5834,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00419de735aac21d53b0de5ce2c03bd3627277cf471300f27ebc89f7d828047"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libra"
@@ -5890,7 +5890,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -5948,7 +5948,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "move-core-types",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "tokio",
  "ureq",
@@ -6105,7 +6105,7 @@ dependencies = [
  "libra-smoke-tests",
  "libra-types",
  "libra-wallet",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "smoke-test",
@@ -6139,7 +6139,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -6189,7 +6189,7 @@ dependencies = [
  "pbkdf2 0.7.5",
  "rand 0.7.3",
  "rpassword",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
@@ -6236,7 +6236,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.213",
+ "serde 1.0.214",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -6347,7 +6347,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -6426,7 +6426,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "toml 0.8.2",
 ]
 
@@ -6512,7 +6512,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6523,13 +6523,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6539,19 +6539,19 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "ref-cast",
- "serde 1.0.213",
+ "serde 1.0.214",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6560,13 +6560,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6609,7 +6609,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6642,7 +6642,7 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "difference",
@@ -6662,7 +6662,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -6670,7 +6670,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6699,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6713,7 +6713,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_bytes",
  "uint",
 ]
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6735,13 +6735,13 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6772,13 +6772,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6786,13 +6786,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6851,13 +6851,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6877,14 +6877,14 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "trace",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6908,7 +6908,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6947,7 +6947,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "simplelog",
  "tokio",
@@ -6957,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6977,7 +6977,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "tera",
  "tokio",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6995,13 +6995,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -7021,13 +7021,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "hex",
@@ -7050,16 +7050,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "better_any",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7162,19 +7162,19 @@ dependencies = [
  "move-table-extension",
  "move-vm-types",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "smallvec",
 ]
 
@@ -7558,7 +7558,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -7653,7 +7653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599fe9aefc2ca0df4a96179b3075faee2cacb89d4cf947a00b9a89152dfffc9d"
 dependencies = [
  "base64 0.13.1",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -7692,7 +7692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -7880,7 +7880,7 @@ dependencies = [
  "regex",
  "rfc7239",
  "rustls-pemfile 1.0.4",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -7923,7 +7923,7 @@ dependencies = [
  "poem-openapi-derive",
  "quick-xml 0.26.0",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -8113,7 +8113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
 dependencies = [
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "time",
  "url",
@@ -8190,7 +8190,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.5",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-value",
  "tint",
 ]
@@ -8236,7 +8236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -8542,7 +8542,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile 1.0.4",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -8569,7 +8569,7 @@ dependencies = [
  "async-trait",
  "http 0.2.12",
  "reqwest",
- "serde 1.0.213",
+ "serde 1.0.214",
  "task-local-extensions",
  "thiserror",
 ]
@@ -9010,9 +9010,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -9027,7 +9027,7 @@ dependencies = [
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde-reflection 0.3.5",
  "serde_bytes",
  "serde_yaml 0.8.26",
@@ -9053,7 +9053,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
@@ -9063,7 +9063,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
@@ -9074,7 +9074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.213",
+ "serde 1.0.214",
  "thiserror",
 ]
 
@@ -9085,7 +9085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -9094,14 +9094,14 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -9118,7 +9118,7 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -9127,7 +9127,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "thiserror",
 ]
@@ -9138,7 +9138,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -9150,7 +9150,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -9164,7 +9164,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.6.0",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -9191,7 +9191,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.213",
+ "serde 1.0.214",
  "yaml-rust",
 ]
 
@@ -9204,7 +9204,7 @@ dependencies = [
  "indexmap 2.6.0",
  "itoa",
  "ryu",
- "serde 1.0.213",
+ "serde 1.0.214",
  "unsafe-libyaml",
 ]
 
@@ -9418,7 +9418,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
+source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#19d020d1ff5a6765bdb1f0900b53e86c71e65c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9699,7 +9699,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "slug",
  "unic-segment",
@@ -9801,7 +9801,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde 1.0.213",
+ "serde 1.0.214",
  "time-core",
  "time-macros",
 ]
@@ -10030,7 +10030,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -10039,7 +10039,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.20.2",
@@ -10051,7 +10051,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -10063,7 +10063,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -10084,7 +10084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.6.0",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -10264,7 +10264,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.213",
+ "serde 1.0.214",
  "tracing-core",
 ]
 
@@ -10278,7 +10278,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -10566,7 +10566,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "url",
 ]
@@ -10580,7 +10580,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
  "percent-encoding",
- "serde 1.0.213",
+ "serde 1.0.214",
 ]
 
 [[package]]
@@ -10705,7 +10705,7 @@ dependencies = [
  "pin-project",
  "rustls-pemfile 2.2.0",
  "scoped-tls",
- "serde 1.0.213",
+ "serde 1.0.214",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -11093,7 +11093,7 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
- "serde 1.0.213",
+ "serde 1.0.214",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,12 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -146,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -161,43 +155,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 dependencies = [
  "backtrace",
 ]
@@ -284,7 +278,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.19",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -320,7 +314,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -358,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -385,9 +379,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -396,24 +390,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -429,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -444,9 +438,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -454,9 +448,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.209",
+ "serde 1.0.213",
  "sync_wrapper",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -470,8 +464,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -480,17 +474,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -528,7 +522,7 @@ name = "bcs"
 version = "0.1.4"
 source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
@@ -538,7 +532,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
@@ -557,23 +551,23 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
 dependencies = [
  "autocfg",
  "libm",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -582,7 +576,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -598,12 +592,12 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -720,8 +714,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
- "serde 1.0.209",
+ "regex-automata 0.4.8",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -738,9 +732,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -750,9 +744,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bzip2-sys"
@@ -793,9 +787,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.1.16"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -833,7 +827,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.19",
- "serde 1.0.209",
+ "serde 1.0.213",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -930,19 +924,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.13",
+ "clap_derive 4.5.18",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -952,11 +946,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.26"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
+checksum = "07a13ab5b8cb13dbe35e68b83f6c12f9293b2f601797b71bc9f23befdb329feb"
 dependencies = [
- "clap 4.5.17",
+ "clap 4.5.20",
 ]
 
 [[package]]
@@ -967,21 +961,21 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1006,7 +1000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -1015,7 +1009,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "termcolor",
  "unicode-width",
 ]
@@ -1028,9 +1022,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -1053,7 +1047,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1065,7 +1059,7 @@ dependencies = [
  "lazy_static 1.5.0",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -1093,22 +1087,22 @@ checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "const_format"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "unicode-xid 0.2.5",
+ "unicode-xid 0.2.6",
 ]
 
 [[package]]
@@ -1142,16 +1136,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie_store"
-version = "0.16.2"
+name = "cookie"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
- "cookie",
- "idna 0.2.3",
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie 0.17.0",
+ "idna 0.3.0",
  "log",
  "publicsuffix",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_derive",
  "serde_json",
  "time",
@@ -1176,9 +1181,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1257,7 +1262,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
@@ -1273,7 +1278,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
@@ -1318,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1335,7 +1340,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -1358,15 +1363,41 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1397,7 +1428,7 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "strsim 0.10.0",
  "syn 1.0.109",
@@ -1411,10 +1442,10 @@ checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1436,7 +1467,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1465,6 +1496,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core 0.9.10",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "datatest-stable"
@@ -1516,7 +1553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -1531,7 +1568,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -1542,9 +1579,9 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1554,10 +1591,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1581,14 +1618,14 @@ dependencies = [
 [[package]]
 name = "diem"
 version = "2.0.2"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
- "clap 4.5.17",
+ "clap 4.5.20",
  "clap_complete",
  "codespan-reporting",
  "diem-api-types",
@@ -1646,7 +1683,7 @@ dependencies = [
  "regex",
  "reqwest",
  "self_update",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "shadow-rs",
@@ -1654,7 +1691,7 @@ dependencies = [
  "termcolor",
  "thiserror",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
  "toml 0.5.11",
  "walkdir",
 ]
@@ -1662,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "diem-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-crypto",
@@ -1672,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "diem-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1690,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "diem-api"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1712,7 +1749,7 @@ dependencies = [
  "fail 0.5.1",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.31",
  "itertools",
  "mime",
  "move-core-types",
@@ -1722,7 +1759,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "tokio",
  "url",
@@ -1731,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "diem-api-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1751,20 +1788,20 @@ dependencies = [
  "move-resource-viewer",
  "poem",
  "poem-openapi",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-backup-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
  "bytes",
- "clap 4.5.17",
+ "clap 4.5.20",
  "csv",
  "diem-backup-service",
  "diem-config",
@@ -1793,19 +1830,19 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
  "tokio-io-timeout",
  "tokio-stream",
- "tokio-util 0.7.12",
+ "tokio-util",
 ]
 
 [[package]]
 name = "diem-backup-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1817,9 +1854,9 @@ dependencies = [
  "diem-runtimes",
  "diem-storage-interface",
  "diem-types",
- "hyper",
+ "hyper 0.14.31",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
  "warp",
 ]
@@ -1827,16 +1864,16 @@ dependencies = [
 [[package]]
 name = "diem-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
 ]
 
 [[package]]
 name = "diem-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1861,11 +1898,11 @@ dependencies = [
 [[package]]
 name = "diem-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dashmap 5.5.3",
  "diem-crypto",
  "diem-logger",
@@ -1881,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "diem-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "futures",
  "tokio",
@@ -1890,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "diem-build-info"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "shadow-rs",
 ]
@@ -1898,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "diem-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "diem-framework",
@@ -1911,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "diem-channels"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -1923,17 +1960,17 @@ dependencies = [
 [[package]]
 name = "diem-cli-common"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anstyle",
- "clap 4.5.17",
+ "clap 4.5.20",
  "clap_complete",
 ]
 
 [[package]]
 name = "diem-compression"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -1945,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "diem-config"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -1965,7 +2002,7 @@ dependencies = [
  "num_cpus",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_merge",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -1975,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2026,7 +2063,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2037,14 +2074,14 @@ dependencies = [
 [[package]]
 name = "diem-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-crypto",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
 ]
@@ -2052,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "diem-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2068,26 +2105,26 @@ dependencies = [
  "mirai-annotations",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
 ]
 
 [[package]]
 name = "diem-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "backtrace",
  "diem-logger",
  "move-core-types",
- "serde 1.0.209",
+ "serde 1.0.213",
  "toml 0.5.11",
 ]
 
 [[package]]
 name = "diem-crypto"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -2096,7 +2133,7 @@ dependencies = [
  "bcs 0.1.4",
  "blst",
  "bytes",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "diem-crypto-derive",
  "digest 0.9.0",
  "ed25519-dalek",
@@ -2110,7 +2147,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring 0.16.20",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde-name",
  "serde_bytes",
  "sha2 0.10.8",
@@ -2124,9 +2161,9 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -2134,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "diem-data-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-config",
@@ -2153,7 +2190,7 @@ dependencies = [
  "futures",
  "itertools",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
 ]
@@ -2161,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "diem-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2178,7 +2215,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2187,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "diem-db"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2195,7 +2232,7 @@ dependencies = [
  "bcs 0.1.4",
  "byteorder",
  "claims",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dashmap 5.5.3",
  "diem-accumulator",
  "diem-config",
@@ -2226,7 +2263,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "static_assertions",
  "status-line",
  "thiserror",
@@ -2235,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "diem-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2255,17 +2292,17 @@ dependencies = [
  "move-core-types",
  "move-resource-viewer",
  "num-derive",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "diem-db-tool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-backup-cli",
  "diem-backup-service",
  "diem-config",
@@ -2285,10 +2322,10 @@ dependencies = [
 [[package]]
 name = "diem-debugger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-crypto",
  "diem-gas",
  "diem-gas-profiling",
@@ -2316,9 +2353,9 @@ dependencies = [
 [[package]]
 name = "diem-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -2326,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "diem-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -2336,14 +2373,14 @@ dependencies = [
  "diem-storage-interface",
  "diem-types",
  "futures",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-executor"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -2368,13 +2405,13 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "diem-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-cached-packages",
@@ -2398,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "diem-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2412,14 +2449,14 @@ dependencies = [
  "diem-types",
  "itertools",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-fallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "thiserror",
 ]
@@ -2427,12 +2464,12 @@ dependencies = [
 [[package]]
 name = "diem-faucet-core"
 version = "2.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
  "captcha",
- "clap 4.5.17",
+ "clap 4.5.20",
  "deadpool-redis",
  "diem-config",
  "diem-faucet-metrics-server",
@@ -2451,7 +2488,7 @@ dependencies = [
  "rand 0.7.3",
  "redis",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -2461,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "diem-faucet-metrics-server"
 version = "2.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-logger",
@@ -2469,20 +2506,20 @@ dependencies = [
  "once_cell",
  "poem",
  "prometheus",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-forge"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem",
  "diem-cached-packages",
  "diem-cli-common",
@@ -2505,11 +2542,11 @@ dependencies = [
  "either",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.31",
  "hyper-tls",
  "itertools",
- "json-patch",
- "k8s-openapi",
+ "json-patch 0.2.7",
+ "k8s-openapi 0.13.1",
  "kube",
  "num_cpus",
  "once_cell",
@@ -2518,7 +2555,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -2531,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "diem-framework"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -2544,9 +2581,9 @@ dependencies = [
  "better_any",
  "blake2-rfc",
  "blst",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan-reporting",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "diem-aggregator",
  "diem-crypto",
  "diem-gas-algebra-ext",
@@ -2579,7 +2616,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rayon",
  "ripemd",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -2596,11 +2633,11 @@ dependencies = [
 [[package]]
 name = "diem-gas"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-framework",
  "diem-gas-algebra-ext",
  "diem-global-constants",
@@ -2619,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-algebra-ext"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "move-core-types",
 ]
@@ -2627,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "diem-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -2645,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "diem-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2664,17 +2701,17 @@ dependencies = [
  "diem-vm",
  "diem-vm-genesis",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_yaml 0.8.26",
 ]
 
 [[package]]
 name = "diem-github-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-proxy",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
  "ureq",
@@ -2683,24 +2720,24 @@ dependencies = [
 [[package]]
 name = "diem-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 
 [[package]]
 name = "diem-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 
 [[package]]
 name = "diem-indexer"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
  "chrono",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-api",
  "diem-api-types",
  "diem-bitvec",
@@ -2722,7 +2759,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "sha2 0.9.9",
  "tokio",
@@ -2732,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "diem-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2754,12 +2791,12 @@ dependencies = [
  "fail 0.5.1",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.31",
  "move-binary-format",
  "move-core-types",
  "move-package",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -2769,12 +2806,12 @@ dependencies = [
 [[package]]
 name = "diem-infallible"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 
 [[package]]
 name = "diem-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-build-info",
@@ -2785,7 +2822,7 @@ dependencies = [
  "diem-network",
  "diem-runtimes",
  "futures",
- "hyper",
+ "hyper 0.14.31",
  "once_cell",
  "prometheus",
  "reqwest",
@@ -2797,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "diem-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2816,14 +2853,14 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-keygen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-crypto",
  "diem-types",
@@ -2833,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "diem-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -2865,15 +2902,15 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "diem-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -2881,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "diem-logger"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "backtrace",
  "chrono",
@@ -2893,7 +2930,7 @@ dependencies = [
  "hostname",
  "once_cell",
  "prometheus",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "strum",
  "strum_macros",
@@ -2905,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "diem-mempool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2935,7 +2972,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2945,13 +2982,13 @@ dependencies = [
 [[package]]
 name = "diem-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-runtimes",
  "diem-types",
  "futures",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
 ]
@@ -2959,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "diem-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bytes",
  "diem-infallible",
@@ -2970,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "diem-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2979,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "diem-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "hex",
@@ -3002,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "diem-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "chrono",
 ]
@@ -3010,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "diem-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3025,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "diem-netcore"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bytes",
  "diem-memsocket",
@@ -3033,16 +3070,16 @@ dependencies = [
  "diem-types",
  "futures",
  "pin-project",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "diem-network"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3073,19 +3110,19 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.12",
+ "tokio-util",
 ]
 
 [[package]]
 name = "diem-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "bcs 0.1.4",
@@ -3104,31 +3141,31 @@ dependencies = [
  "futures",
  "maplit",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-checker"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-config",
  "diem-crypto",
  "diem-logger",
  "diem-network",
  "diem-types",
  "futures",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
 ]
 
 [[package]]
 name = "diem-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3154,11 +3191,11 @@ dependencies = [
 [[package]]
 name = "diem-node"
 version = "1.6.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-api",
  "diem-backup-service",
  "diem-build-info",
@@ -3208,7 +3245,7 @@ dependencies = [
  "maplit",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3219,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "diem-node-identity"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "claims",
@@ -3231,9 +3268,9 @@ dependencies = [
 [[package]]
 name = "diem-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -3241,20 +3278,20 @@ dependencies = [
 [[package]]
 name = "diem-openapi"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "percent-encoding",
  "poem",
  "poem-openapi",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-framework",
@@ -3267,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3284,7 +3321,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3293,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3312,7 +3349,7 @@ dependencies = [
  "diem-types",
  "futures",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
 ]
@@ -3320,20 +3357,20 @@ dependencies = [
 [[package]]
 name = "diem-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "cfg_block",
  "diem-config",
  "diem-types",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -3343,18 +3380,18 @@ dependencies = [
 [[package]]
 name = "diem-protos"
 version = "1.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "pbjson",
  "prost",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tonic",
 ]
 
 [[package]]
 name = "diem-proxy"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "ipnet",
 ]
@@ -3362,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "diem-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
@@ -3373,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "diem-rate-limiter"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-infallible",
  "diem-logger",
@@ -3381,17 +3418,17 @@ dependencies = [
  "futures",
  "pin-project",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
 ]
 
 [[package]]
 name = "diem-release-builder"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem",
  "diem-api-types",
  "diem-build-info",
@@ -3411,7 +3448,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -3423,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "diem-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-types",
@@ -3435,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "diem-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3451,7 +3488,7 @@ dependencies = [
  "move-core-types",
  "poem-openapi",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3461,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "diem-retrier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-logger",
  "tokio",
@@ -3470,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "diem-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-config",
  "rocksdb",
@@ -3479,11 +3516,11 @@ dependencies = [
 [[package]]
 name = "diem-rosetta"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-cached-packages",
  "diem-config",
  "diem-crypto",
@@ -3502,7 +3539,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -3513,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "diem-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "tokio",
 ]
@@ -3521,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "diem-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-config",
  "diem-consensus-types",
@@ -3537,7 +3574,7 @@ dependencies = [
  "diem-vault-client",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
 ]
@@ -3545,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "diem-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-infallible",
@@ -3559,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "diem-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bitvec 0.19.6",
  "diem-crypto",
@@ -3576,7 +3613,7 @@ dependencies = [
 [[package]]
 name = "diem-sdk"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -3589,18 +3626,18 @@ dependencies = [
  "ed25519-dalek-bip32",
  "move-core-types",
  "rand_core 0.5.1",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "diem-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-types",
  "heck 0.3.3",
  "move-core-types",
@@ -3615,19 +3652,19 @@ dependencies = [
 [[package]]
 name = "diem-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-logger",
  "diem-metrics-core",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3641,7 +3678,7 @@ dependencies = [
  "diem-vault-client",
  "enum_dispatch",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
 ]
@@ -3649,10 +3686,10 @@ dependencies = [
 [[package]]
 name = "diem-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "mirai-annotations",
- "serde 1.0.209",
+ "serde 1.0.213",
  "static_assertions",
  "thiserror",
 ]
@@ -3660,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "diem-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -3672,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "diem-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3698,7 +3735,7 @@ dependencies = [
  "futures",
  "once_cell",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3707,13 +3744,13 @@ dependencies = [
 [[package]]
 name = "diem-state-view"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "diem-crypto",
  "diem-types",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "serde_json",
 ]
@@ -3721,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3741,14 +3778,14 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "async-trait",
  "diem-channels",
@@ -3762,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-server"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "bytes",
@@ -3780,7 +3817,7 @@ dependencies = [
  "futures",
  "lru 0.7.8",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
  "tokio",
 ]
@@ -3788,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "diem-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "diem-compression",
@@ -3796,14 +3833,14 @@ dependencies = [
  "diem-crypto",
  "diem-types",
  "num-traits 0.2.19",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3812,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "diem-time-service"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "diem-infallible",
  "enum_dispatch",
@@ -3825,12 +3862,12 @@ dependencies = [
 [[package]]
 name = "diem-transaction-emitter-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem",
  "diem-config",
  "diem-crypto",
@@ -3848,7 +3885,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
  "url",
 ]
@@ -3856,12 +3893,12 @@ dependencies = [
 [[package]]
 name = "diem-transaction-generator-lib"
 version = "0.0.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "again",
  "anyhow",
  "async-trait",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem",
  "diem-config",
  "diem-crypto",
@@ -3878,7 +3915,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "tokio",
  "url",
 ]
@@ -3886,11 +3923,11 @@ dependencies = [
 [[package]]
 name = "diem-transactional-test-harness"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-api-types",
  "diem-cached-packages",
  "diem-crypto",
@@ -3911,14 +3948,14 @@ dependencies = [
  "move-transactional-test-runner",
  "move-vm-runtime",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
 ]
 
 [[package]]
 name = "diem-types"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arr_macro",
@@ -3940,7 +3977,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3951,12 +3988,12 @@ dependencies = [
 [[package]]
 name = "diem-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 
 [[package]]
 name = "diem-validator-interface"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3977,14 +4014,14 @@ dependencies = [
 [[package]]
 name = "diem-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "base64 0.13.1",
  "chrono",
  "diem-crypto",
  "native-tls",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
  "ureq",
@@ -3993,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "diem-vm"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4031,7 +4068,7 @@ dependencies = [
  "ouroboros 0.15.6",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "smallvec",
  "tracing",
@@ -4040,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -4055,13 +4092,13 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "diem-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "arc-swap",
  "diem-crypto",
@@ -4071,13 +4108,13 @@ dependencies = [
  "diem-state-view",
  "diem-types",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "diem-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-aggregator",
@@ -4090,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "diem-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "diem-gas",
@@ -4105,15 +4142,15 @@ dependencies = [
 [[package]]
 name = "diem-warp-webserver"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
  "diem-api-types",
  "diem-config",
  "diem-logger",
- "hyper",
- "serde 1.0.209",
+ "hyper 0.14.31",
+ "serde 1.0.213",
  "serde_json",
  "warp",
 ]
@@ -4146,9 +4183,9 @@ checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4168,7 +4205,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4256,9 +4293,9 @@ dependencies = [
  "darling 0.20.10",
  "either",
  "heck 0.5.0",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4267,7 +4304,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "signature",
 ]
 
@@ -4277,10 +4314,10 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -4312,9 +4349,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -4326,9 +4363,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4362,7 +4399,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -4411,12 +4448,18 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field_count"
@@ -4463,12 +4506,21 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4515,9 +4567,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4530,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4540,15 +4592,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4557,38 +4609,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 1.0.109",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4647,10 +4699,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4678,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -4718,15 +4768,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
 dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4742,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "goldenfile"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d5c44265baec620ea19c97b4ce9f068e28f8c3d7faccc483f02968b5e3c587"
+checksum = "672ff1c2f0537cf3f92065ce8aa77e2fc3f2abae2c805eb67f40ceecfbdee428"
 dependencies = [
  "scopeguard",
  "similar-asserts",
@@ -4763,11 +4813,11 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.5.0",
+ "http 0.2.12",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4780,7 +4830,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
 ]
@@ -4810,6 +4860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,8 +4873,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "headers-core",
- "http",
+ "headers-core 0.2.0",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -4830,7 +4901,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -4881,7 +4961,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -4919,7 +4999,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.1",
+ "crypto-mac 0.10.0",
  "digest 0.9.0",
 ]
 
@@ -4941,6 +5021,15 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4972,27 +5061,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -5011,17 +5128,17 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -5034,18 +5151,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.2"
+name = "hyper"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
- "http",
- "hyper",
- "log",
- "rustls 0.20.9",
- "rustls-native-certs",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
  "tokio",
- "tokio-rustls 0.23.4",
+ "want",
+]
+
+[[package]]
+name = "hyper-http-proxy"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers 0.4.0",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-util",
+ "log",
+ "rustls 0.23.16",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -5054,10 +5214,23 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.5.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -5067,17 +5240,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
+name = "hyper-util"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5104,17 +5296,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -5135,15 +5316,15 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
  "crossbeam-deque",
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -5191,7 +5372,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -5200,7 +5381,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -5234,7 +5415,7 @@ checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
 dependencies = [
  "anyhow",
  "proc-macro-hack",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -5245,7 +5426,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
 ]
 
@@ -5257,18 +5438,18 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
- "serde 1.0.209",
+ "hashbrown 0.15.0",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -5297,12 +5478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.11",
- "clap 4.5.17",
+ "clap 4.5.20",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "is-terminal",
  "itoa",
  "log",
@@ -5349,9 +5530,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "iprange"
@@ -5432,9 +5613,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5445,19 +5626,46 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "treediff",
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "json-patch"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
- "log",
- "serde 1.0.209",
+ "jsonptr",
+ "serde 1.0.213",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static 1.5.0",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde 1.0.213",
  "serde_json",
 ]
 
@@ -5470,7 +5678,20 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "serde 1.0.209",
+ "serde 1.0.213",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde 1.0.213",
  "serde-value",
  "serde_json",
 ]
@@ -5486,63 +5707,66 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.65.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec231e9ec9e84789f9eb414d1ac40ce6c90d0517fb272a335b4233f2e272b1e"
+checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
 dependencies = [
- "k8s-openapi",
+ "k8s-openapi 0.23.0",
  "kube-client",
  "kube-core",
 ]
 
 [[package]]
 name = "kube-client"
-version = "0.65.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95dddb1fcced906d79cdae530ff39079c2d3772b2d623088fdbebe610bfa8217"
+checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
- "http",
- "http-body",
- "hyper",
+ "home",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-http-proxy",
  "hyper-rustls",
- "hyper-timeout",
- "jsonpath_lib",
- "k8s-openapi",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi 0.23.0",
  "kube-core",
  "pem",
- "pin-project",
- "rustls 0.20.9",
- "rustls-pemfile 0.2.1",
- "serde 1.0.209",
+ "rustls 0.23.16",
+ "rustls-pemfile 2.2.0",
+ "secrecy",
+ "serde 1.0.213",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
- "tokio-util 0.6.10",
- "tower",
+ "tokio-util",
+ "tower 0.5.1",
  "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.65.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52b6ab05d160691083430f6f431707a4e05b64903f2ffa0095ee5efde759117"
+checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http",
- "json-patch",
- "k8s-openapi",
- "once_cell",
- "serde 1.0.209",
+ "http 1.1.0",
+ "json-patch 2.0.0",
+ "k8s-openapi 0.23.0",
+ "serde 1.0.213",
+ "serde-value",
  "serde_json",
  "thiserror",
 ]
@@ -5580,9 +5804,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libgit2-sys"
@@ -5610,16 +5834,16 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "a00419de735aac21d53b0de5ce2c03bd3627277cf471300f27ebc89f7d828047"
 
 [[package]]
 name = "libra"
 version = "7.0.3"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem",
  "diem-config",
  "diem-node",
@@ -5654,7 +5878,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem",
  "diem-config",
@@ -5666,7 +5890,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tokio",
@@ -5679,7 +5903,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem",
  "diem-build-info",
@@ -5701,7 +5925,7 @@ dependencies = [
  "base64 0.13.1",
  "bcs 0.1.4",
  "chrono",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem-config",
  "diem-crypto",
@@ -5724,7 +5948,7 @@ dependencies = [
  "libra-types",
  "libra-wallet",
  "move-core-types",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "tokio",
  "ureq",
@@ -5735,7 +5959,7 @@ name = "libra-query"
 version = "7.0.3"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-api-types",
  "diem-debugger",
  "diem-sdk",
@@ -5754,7 +5978,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-api-types",
  "diem-config",
  "diem-crypto",
@@ -5810,7 +6034,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "diem-backup-cli",
  "diem-config",
  "diem-db",
@@ -5833,7 +6057,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem-api-types",
  "diem-config",
@@ -5862,7 +6086,7 @@ version = "7.0.3"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem",
  "diem-forge",
@@ -5881,7 +6105,7 @@ dependencies = [
  "libra-smoke-tests",
  "libra-types",
  "libra-wallet",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "smoke-test",
@@ -5896,7 +6120,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "console",
  "diem",
  "diem-api-types",
@@ -5915,7 +6139,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -5950,7 +6174,7 @@ dependencies = [
  "anyhow",
  "blst",
  "byteorder",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "diem-config",
  "diem-crypto",
@@ -5965,7 +6189,7 @@ dependencies = [
  "pbkdf2 0.7.5",
  "rand 0.7.3",
  "rpassword",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
@@ -6012,7 +6236,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.209",
+ "serde 1.0.213",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -6123,7 +6347,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -6146,19 +6370,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
 dependencies = [
- "libc",
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -6186,12 +6409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6209,7 +6426,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "toml 0.8.2",
 ]
 
@@ -6220,7 +6437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
 ]
 
@@ -6248,21 +6465,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
- "simd-adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -6275,6 +6483,18 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6292,7 +6512,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6303,13 +6523,13 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6319,19 +6539,19 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "ref-cast",
- "serde 1.0.209",
+ "serde 1.0.213",
  "variant_count",
 ]
 
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6340,13 +6560,13 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6358,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "fail 0.4.0",
@@ -6372,10 +6592,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "crossterm 0.26.1",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6389,11 +6609,11 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan-reporting",
  "colored",
  "difference",
@@ -6422,7 +6642,7 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -6433,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "difference",
@@ -6442,7 +6662,7 @@ dependencies = [
  "move-core-types",
  "num-bigint",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -6450,11 +6670,11 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan-reporting",
  "difference",
  "hex",
@@ -6479,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6493,7 +6713,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_bytes",
  "uint",
 ]
@@ -6501,11 +6721,11 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan",
  "colored",
  "move-binary-format",
@@ -6515,16 +6735,16 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6539,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6552,13 +6772,13 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6566,17 +6786,17 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -6591,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6610,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6623,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6631,13 +6851,13 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6657,18 +6877,18 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "trace",
 ]
 
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
- "clap 4.5.17",
+ "clap 4.5.20",
  "colored",
  "dirs-next",
  "itertools",
@@ -6688,7 +6908,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
@@ -6700,12 +6920,12 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -6727,7 +6947,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "simplelog",
  "tokio",
@@ -6737,7 +6957,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6757,7 +6977,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "tera",
  "tokio",
@@ -6766,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6775,13 +6995,13 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6801,13 +7021,13 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "hex",
@@ -6830,16 +7050,16 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -6856,10 +7076,10 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
- "clap 4.5.17",
+ "clap 4.5.20",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -6887,11 +7107,11 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "better_any",
- "clap 4.5.17",
+ "clap 4.5.20",
  "codespan-reporting",
  "colored",
  "itertools",
@@ -6917,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6934,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6942,19 +7162,19 @@ dependencies = [
  "move-table-extension",
  "move-vm-types",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "bcs 0.1.4",
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "smallvec",
 ]
 
@@ -6967,7 +7187,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -7099,7 +7319,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -7191,18 +7411,18 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -7212,9 +7432,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -7231,9 +7451,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7244,9 +7464,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -7297,7 +7517,7 @@ checksum = "03f2cb802b5bdfdf52f1ffa0b54ce105e4d346e91990dd571f86c91321ad49e2"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -7310,7 +7530,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -7338,7 +7558,7 @@ dependencies = [
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -7348,7 +7568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -7396,7 +7616,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -7433,16 +7653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599fe9aefc2ca0df4a96179b3075faee2cacb89d4cf947a00b9a89152dfffc9d"
 dependencies = [
  "base64 0.13.1",
- "serde 1.0.209",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac 0.8.0",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -7452,10 +7663,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
 dependencies = [
  "base64ct",
- "crypto-mac 0.10.1",
+ "crypto-mac 0.10.0",
  "hmac 0.10.1",
  "password-hash",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -7466,11 +7687,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -7481,9 +7703,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -7492,9 +7714,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7502,22 +7724,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -7541,7 +7763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -7584,29 +7806,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -7616,21 +7838,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -7643,11 +7865,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
- "cookie",
+ "cookie 0.16.2",
  "futures-util",
- "headers",
- "http",
- "hyper",
+ "headers 0.3.9",
+ "http 0.2.12",
+ "hyper 0.14.31",
  "mime",
  "multer",
  "parking_lot 0.12.3",
@@ -7658,7 +7880,7 @@ dependencies = [
  "regex",
  "rfc7239",
  "rustls-pemfile 1.0.4",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -7669,7 +7891,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
- "tokio-util 0.7.12",
+ "tokio-util",
  "tracing",
 ]
 
@@ -7680,9 +7902,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
  "proc-macro-crate 2.0.2",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7701,7 +7923,7 @@ dependencies = [
  "poem-openapi-derive",
  "quick-xml 0.26.0",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml 0.9.34+deprecated",
@@ -7717,11 +7939,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88c3e2975c930dc72c024e75b230c3b6058fb3a746d5739b83aa8f28ab1a42d4"
 dependencies = [
  "darling 0.14.4",
- "http",
+ "http 0.2.12",
  "indexmap 1.9.3",
  "mime",
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "regex",
  "syn 1.0.109",
@@ -7742,9 +7964,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -7763,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "pq-sys"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ff9e4cf6945c988f0db7005d87747bf72864965c3529d259ad155ac41d584"
+checksum = "f6cc05d7ea95200187117196eee9edd0644424911821aeb28a18ce60ea0b8793"
 dependencies = [
  "vcpkg",
 ]
@@ -7782,12 +8004,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
- "proc-macro2 1.0.86",
- "syn 2.0.77",
+ "proc-macro2 1.0.89",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7829,7 +8051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
  "version_check",
@@ -7841,7 +8063,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "version_check",
 ]
@@ -7863,9 +8085,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -7891,7 +8113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
 dependencies = [
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "time",
  "url",
@@ -7911,7 +8133,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -7946,7 +8168,7 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -7968,7 +8190,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.5",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde-value",
  "tint",
 ]
@@ -8014,7 +8236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -8032,7 +8254,7 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
 ]
 
 [[package]]
@@ -8195,7 +8417,7 @@ dependencies = [
  "ryu",
  "sha1_smol",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
  "url",
 ]
 
@@ -8210,9 +8432,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -8243,21 +8465,21 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8271,13 +8493,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8288,27 +8510,27 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "cookie",
+ "cookie 0.17.0",
  "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -8319,13 +8541,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.209",
+ "rustls-pemfile 1.0.4",
+ "serde 1.0.213",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.12",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8343,9 +8567,9 @@ checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.12",
  "reqwest",
- "serde 1.0.209",
+ "serde 1.0.213",
  "task-local-extensions",
  "thiserror",
 ]
@@ -8361,8 +8585,8 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.2.15",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.31",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -8502,9 +8726,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -8533,8 +8757,37 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -8550,12 +8803,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
+name = "rustls-native-certs"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "base64 0.13.1",
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -8568,6 +8838,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8578,10 +8863,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
+name = "rustls-webpki"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -8612,11 +8908,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8651,6 +8947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8665,9 +8970,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -8679,7 +8984,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28d58e73c427061f46c801176f54349be3c1a2818cf549e1d9bcac37eef7bca"
 dependencies = [
- "hyper",
+ "hyper 0.14.31",
  "indicatif",
  "log",
  "quick-xml 0.22.0",
@@ -8705,9 +9010,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -8722,7 +9027,7 @@ dependencies = [
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde-reflection 0.3.5",
  "serde_bytes",
  "serde_yaml 0.8.26",
@@ -8748,7 +9053,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
@@ -8758,7 +9063,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
@@ -8769,7 +9074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.209",
+ "serde 1.0.213",
  "thiserror",
 ]
 
@@ -8780,7 +9085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -8789,31 +9094,31 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -8822,18 +9127,18 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606e91878516232ac3b16c12e063d4468d762f16d77e7aef14a1f2326c5f409b"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -8845,21 +9150,21 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
- "serde 1.0.209",
+ "indexmap 2.6.0",
+ "serde 1.0.213",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -8868,14 +9173,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.10",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8886,7 +9191,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap 1.9.3",
  "ryu",
- "serde 1.0.209",
+ "serde 1.0.213",
  "yaml-rust",
 ]
 
@@ -8896,10 +9201,10 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
- "serde 1.0.209",
+ "serde 1.0.213",
  "unsafe-libyaml",
 ]
 
@@ -9007,7 +9312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -9044,9 +9349,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
 dependencies = [
  "console",
  "similar",
@@ -9113,7 +9418,7 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 [[package]]
 name = "smoke-test"
 version = "0.1.0"
-source = "git+https://github.com/0LNetworkCommunity/diem.git?branch=release#fe9453ded98e8d21c63772a9d3c6bc1e5d235fe1"
+source = "git+https://github.com/dboreham/diem.git?branch=dependency-updates-1024#bfc20812f544477e584c5cbca43f1bae2afdc40b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9245,7 +9550,7 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -9263,7 +9568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "rustversion",
  "syn 1.0.109",
@@ -9271,9 +9576,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -9292,18 +9597,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "unicode-ident",
 ]
@@ -9367,9 +9672,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -9394,7 +9699,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "slug",
  "unic-segment",
@@ -9447,22 +9752,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -9496,7 +9801,7 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde 1.0.209",
+ "serde 1.0.213",
  "time-core",
  "time-macros",
 ]
@@ -9528,17 +9833,15 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
- "anyhow",
- "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
  "rustc-hash",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -9571,21 +9874,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.1"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d57dcc6bb4cf084e3212e1858447222aa451f21b5e2452497d9100da65b91"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9600,24 +9902,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "tokio-metrics"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb585a0069b53171684e22d5255984ec30d1c7304fd0a4a9a603ffd8c765cdd"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
 dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -9663,6 +9966,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.16",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9675,28 +10000,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -9719,7 +10030,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -9728,7 +10039,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.20.2",
@@ -9740,7 +10051,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -9752,7 +10063,7 @@ dependencies = [
  "combine",
  "indexmap 1.9.3",
  "itertools",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -9761,7 +10072,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
 ]
@@ -9772,8 +10083,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.5.0",
- "serde 1.0.209",
+ "indexmap 2.6.0",
+ "serde 1.0.213",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -9794,21 +10105,21 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost",
  "prost-derive",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.7.12",
- "tower",
+ "tokio-util",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9829,7 +10140,24 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.12",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9837,18 +10165,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -9873,7 +10199,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
  "syn 1.0.109",
 ]
@@ -9896,9 +10222,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -9938,7 +10264,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.209",
+ "serde 1.0.213",
  "tracing-core",
 ]
 
@@ -9952,7 +10278,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -10001,14 +10327,14 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "data-encoding",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -10053,18 +10379,18 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1889fdffac09d65c1d95c42d5202e9b21ad8c758f426e9fe09088817ea998d6"
+checksum = "654c1ec546942ce0594e8d220e6b8e3899e0a0a8fe70ddd54d32a376dfefe3f8"
 dependencies = [
  "tz-rs",
 ]
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -10145,24 +10471,21 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -10172,24 +10495,24 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -10199,9 +10522,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -10243,7 +10566,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "url",
 ]
@@ -10257,7 +10580,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
  "percent-encoding",
- "serde 1.0.209",
+ "serde 1.0.213",
 ]
 
 [[package]]
@@ -10364,32 +10687,31 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "headers",
- "http",
- "hyper",
+ "headers 0.3.9",
+ "http 0.2.12",
+ "hyper 0.14.31",
  "log",
  "mime",
  "mime_guess",
  "multer",
  "percent-encoding",
  "pin-project",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.2.0",
  "scoped-tls",
- "serde 1.0.209",
+ "serde 1.0.213",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.23.4",
- "tokio-stream",
+ "tokio-rustls 0.25.0",
  "tokio-tungstenite",
- "tokio-util 0.7.12",
+ "tokio-util",
  "tower-service",
  "tracing",
 ]
@@ -10414,9 +10736,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10425,24 +10747,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -10452,9 +10774,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote 1.0.37",
  "wasm-bindgen-macro-support",
@@ -10462,28 +10784,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -10509,9 +10831,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10533,7 +10855,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
  "wasite",
  "web-sys",
 ]
@@ -10765,12 +11087,13 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
- "rand_core 0.5.1",
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "serde 1.0.213",
  "zeroize",
 ]
 
@@ -10805,16 +11128,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -10825,9 +11148,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.86",
+ "proc-macro2 1.0.89",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,6 +283,10 @@ tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.70"
+# NOTE: The goal is to have the tokio dependencies (which are mostly built from the same repo)
+# have latest and consistent revisions. The selected revisions should be checked to verify
+# that transitive dependencies haven't regressed versions. When the tokio project publishes
+# new minor versions, the specifiers below will need to be updated accordingly.
 tokio = { version = "1", features = ["full"] }
 tokio-io-timeout = "1"
 tokio-metrics = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ criterion-cpu-time = "0.1.0"
 crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 csv = "1.2.1"
-curve25519-dalek = "3"
+curve25519-dalek = "4"
 dashmap = "5.2.0"
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
@@ -158,10 +158,13 @@ fail = "0.5.0"
 field_count = "0.1.1"
 flate2 = "1.0.24"
 fs_extra = "1.2.0"
-futures = "= 0.3.24" # Previously futures v0.3.23 caused some consensus network_tests to fail. We now pin the dependency to v0.3.24.
-futures-channel = "= 0.3.24"
-futures-core = "0.3.25"
-futures-util = "0.3.21"
+# NOTE: Another group of libraries that probably should be kept in version lock-step
+# 0.3.31 is just the latest release when I last changed the version here.
+# In general the latest should be used, or whatever works with the selected tokio
+futures = "0.3.31"
+futures-channel = "0.3"
+futures-core = "0.3"
+futures-util = "0.3"
 gcp-bigquery-client = "0.13.0"
 get_if_addrs = "0.5.3"
 git2 = "0.16.1"
@@ -275,18 +278,18 @@ tempfile = "3.3.0"
 termcolor = "1.1.2"
 textwrap = "0.15.0"
 thiserror = "1.0.37"
-tiny-bip39 = "0.8.2"
+tiny-bip39 = "2"
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 trybuild = "1.0.70"
-tokio = { version = "1.21.0", features = ["full"] }
-tokio-io-timeout = "1.2.0"
-tokio-metrics = "0.1.0"
-tokio-retry = "0.3.0"
-tokio-stream = "0.1.8"
-tokio-test = "0.4.1"
-tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
+tokio = { version = "1", features = ["full"] }
+tokio-io-timeout = "1"
+tokio-metrics = "0.3"
+tokio-retry = "0.3"
+tokio-stream = "0.1"
+tokio-test = "0.4"
+tokio-util = { version = "0.7", features = ["compat", "codec"] }
 toml = "0.5.9"
 tonic = { version = "0.8.3", features = [
   "tls-roots",
@@ -306,7 +309,7 @@ walkdir = "2.3.2"
 warp = { version = "0.3.3", features = ["tls"] }
 warp-reverse-proxy = "0.5.0"
 which = "4.2.5"
-x25519-dalek = "1.2.0"
+x25519-dalek = "2"
 
 ######## 0L #########
 colored = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ criterion-cpu-time = "0.1.0"
 crossbeam = "0.8.1"
 crossbeam-channel = "0.5.4"
 csv = "1.2.1"
-curve25519-dalek = "4"
+curve25519-dalek = "3" # Latest is 4.x.x but we have to stick with 3.x.x due to api changes requiring significant application code changes.
 dashmap = "5.2.0"
 datatest-stable = "0.1.1"
 debug-ignore = { version = "1.0.3", features = ["serde"] }
@@ -147,8 +147,8 @@ diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs = "4.0.0"
-ed25519-dalek = { version = "1.0.1", features = ["std", "serde"] }
-ed25519-dalek-bip32 = "0.2.0"
+ed25519-dalek = { version = "1", features = ["std", "serde"] } # Latest is 2.x.x but we have to stick with 1.x.x due to api changes requiring significant application code changes.
+ed25519-dalek-bip32 = "0.2" # Latest is 3.x.x but we have to stick with 2.x.x due to api changes requiring significant application code changes.
 either = "1.6.1"
 enum_dispatch = "0.3.8"
 env_logger = "0.9.0"
@@ -313,7 +313,9 @@ walkdir = "2.3.2"
 warp = { version = "0.3.3", features = ["tls"] }
 warp-reverse-proxy = "0.5.0"
 which = "4.2.5"
-x25519-dalek = "2"
+# Latest is 2.x.x but we have to stick with 1.2.x due to api changes requiring significant application code changes.
+# We're using a forked version here only to force the transitive dependency "zeroize" off of the upstream's pinned old version.
+x25519-dalek = { git = "https://github.com/0LNetworkCommunity/x25519-dalek", branch = "zeroize_v1" }
 
 ######## 0L #########
 colored = "2.0.0"


### PR DESCRIPTION
This PR brings libra-framework into line with the current diem project transitive dependency set which in turn means we can add new dependencies and not run into version skew errors.