### PR TITLE
WIP [move] validator auction includes random sampling

### DIFF
--- a/framework/libra-framework/sources/ol_sources/mock.move
+++ b/framework/libra-framework/sources/ol_sources/mock.move
@@ -22,6 +22,7 @@ module ol_framework::mock {
   use ol_framework::epoch_helper;
   use ol_framework::musical_chairs;
   use ol_framework::infra_escrow;
+  use ol_framework::randomness;
 
   // use diem_std::debug::print;
 
@@ -108,7 +109,6 @@ module ol_framework::mock {
 
   #[test_only]
   public fun mock_bids(vals: &vector<address>): (vector<u64>, vector<u64>) {
-    // system_addresses::assert_ol(vm);
     let bids = vector::empty<u64>();
     let expiry = vector::empty<u64>();
     let i = 0;
@@ -138,6 +138,8 @@ module ol_framework::mock {
     system_addresses::assert_ol(root);
     genesis::setup();
     genesis::test_end_genesis(root);
+
+    randomness::initialize_for_testing(root);
 
     let mint_cap = coin_init_minimal(root);
     libra_coin::restore_mint_cap(root, mint_cap);

--- a/framework/libra-framework/sources/ol_sources/sortition.move
+++ b/framework/libra-framework/sources/ol_sources/sortition.move
@@ -42,12 +42,15 @@ module ol_framework::sortition {
 
     public fun weighted_sample(weights: vector<u64>, n: u64): vector<u64> {
       let selected_indices = vector::empty();
+      if (n == 0) {
+        return selected_indices
+      };
 
       let i = 0;
       // sample once
       while (i < n) {
         // regenerate the weight after every selection
-        let total_weight  = vector::fold(weights, 0, |acc, x| acc + x);
+        let total_weight = vector::fold(weights, 0, |acc, x| acc + x);
 
         // Step 1: Generate a random number in the range of total_weight
         let random_number = randomness::u64_range(0, total_weight);
@@ -76,10 +79,6 @@ module ol_framework::sortition {
             i = i + 1;
         };
 
-        if (vector::length(&selected_indices) > n) {
-            // trim just in case
-            let _ = vector::trim(&mut selected_indices, n);
-        };
 
         return selected_indices
     }
@@ -96,7 +95,7 @@ module ol_framework::sortition {
         // TODO: check this
 
         let indexes_again = weighted_sample(weights, 3);
-        assert!(vector::length(&indexes) == 3, 7357001);
+        assert!(vector::length(&indexes_again)== 3, 7357001);
 
         // should not be the same
         let res = comparator::compare(&indexes, &indexes_again);

--- a/framework/libra-framework/sources/ol_sources/sortition.move
+++ b/framework/libra-framework/sources/ol_sources/sortition.move
@@ -110,7 +110,7 @@ module ol_framework::sortition {
     /// # Arguments
     /// * `items` - A mutable reference to a vector of u64 indices.
     /// * `rng` - A random generator instance.
-    public fun shuffle(items: &mut vector<u64>) {
+    public fun shuffle<T>(items: &mut vector<T>) {
       let len = vector::length(items);
       if (len == 0) { return };
 

--- a/framework/libra-framework/sources/ol_sources/sortition.move
+++ b/framework/libra-framework/sources/ol_sources/sortition.move
@@ -1,0 +1,139 @@
+
+
+module ol_framework::sortition {
+    use std::vector;
+    use ol_framework::randomness;
+    // use diem_std::debug::print;
+
+    /// # weighted_sample
+    ///
+    /// This function performs weighted random sampling without replacement. Given a vector of weights
+    /// and a number `n`, it returns a vector of `n` indices, where each index is selected based on the
+    /// weight of the corresponding element in the input vector.
+    ///
+    /// ## Parameters
+    ///
+    /// - `weights`: A vector of `u64` representing the weights of the items to be sampled.
+    /// - `n`: A `u64` representing the number of items to sample.
+    ///
+    /// ## Returns
+    ///
+    /// A vector of `u64` containing the indices of the sampled items.
+    ///
+    /// ## Algorithm
+    ///
+    /// 1. Calculate the total weight by summing all the weights in the input vector.
+    /// 2. Initialize an empty vector to store the selected indices.
+    /// 3. Repeat the following steps `n` times:
+    ///    - Generate a random number in the range of the total weight.
+    ///    - Iterate through the weights to find the item corresponding to the random number using cumulative weights.
+    ///    - Add the index of the selected item to the result vector and set its weight to 0 to remove it from the pool.
+    /// 4. If the number of selected indices exceeds `n`, trim the result vector to contain exactly `n` elements.
+    ///
+    /// ## Example Usage
+    ///
+    /// ```move
+    /// let weights = vector[10, 5, 15, 20, 25];
+    /// let n = 3;
+    /// let sampled_indices = weighted_sample(weights, n);
+    /// ```
+    ///
+    /// This function ensures that the items are sampled based on their weights and that no item is selected more than once.
+
+    public fun weighted_sample(weights: vector<u64>, n: u64): vector<u64> {
+      let selected_indices = vector::empty();
+
+      let i = 0;
+      // sample once
+      while (i < n) {
+        // regenerate the weight after every selection
+        let total_weight  = vector::fold(weights, 0, |acc, x| acc + x);
+
+        // Step 1: Generate a random number in the range of total_weight
+        let random_number = randomness::u64_range(0, total_weight);
+
+        // Step 2: Find the selected item using cumulative weights
+        let cumulative_weight = 0;
+        let j = 0;
+        while (j < vector::length(&weights)){
+            let weight = *vector::borrow(&weights, j);
+            cumulative_weight = cumulative_weight + weight;
+
+            if (random_number < cumulative_weight) {
+                // Select this item
+                vector::push_back(&mut selected_indices, j);
+                // and remove from the pool by setting its weight to 0
+                // this does not shuffle the original order of the weights
+                // so we can get the original indexes
+                let value = vector::borrow_mut(&mut weights, j);
+                *value = 0;
+
+                break
+            };
+            j = j + 1;
+        };
+
+            i = i + 1;
+        };
+
+        if (vector::length(&selected_indices) > n) {
+            // trim just in case
+            let _ = vector::trim(&mut selected_indices, n);
+        };
+
+        return selected_indices
+    }
+
+    #[test(framework=@ol_framework)]
+    fun test_weighted_sample(framework: &signer) {
+        use diem_std::comparator;
+
+        randomness::initialize_for_testing(framework);
+        let weights = vector[10, 5, 15, 20, 25];
+
+        let indexes = weighted_sample(weights, 3);
+        assert!(vector::length(&indexes) == 3, 7357001);
+        // TODO: check this
+
+        let indexes_again = weighted_sample(weights, 3);
+        assert!(vector::length(&indexes) == 3, 7357001);
+
+        // should not be the same
+        let res = comparator::compare(&indexes, &indexes_again);
+        assert!(!comparator::is_equal(&res), 7357002);
+    }
+
+
+
+    /// Perform an in-place Fisher-Yates shuffle on a vector of indices.
+    /// TL;DR take each element and swap it with a random element in the
+    // paying attention not to swap an element with a previously shuffled one.
+    /// # Arguments
+    /// * `items` - A mutable reference to a vector of u64 indices.
+    /// * `rng` - A random generator instance.
+    public fun shuffle(items: &mut vector<u64>) {
+      let len = vector::length(items);
+      if (len == 0) { return };
+
+      let i = 0;
+      while (i < len) {
+          let rand_idx = randomness::u64_range(i, len);
+          vector::swap(items, rand_idx, i);
+          i = i + 1;
+      }
+    }
+
+    #[test(framework=@ol_framework)]
+    fun test_shuffle(framework: &signer) {
+        use diem_std::comparator;
+
+        randomness::initialize_for_testing(framework);
+        let original_items = vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let items = vector[1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        shuffle(&mut items);
+        assert!(vector::length(&items) == 10, 7357001);
+        let res = comparator::compare(&original_items, &items);
+        assert!(!comparator::is_equal(&res), 7357002);
+    }
+}

--- a/framework/libra-framework/sources/randomness.move
+++ b/framework/libra-framework/sources/randomness.move
@@ -31,8 +31,6 @@ module diem_framework::randomness {
     use diem_framework::transaction_context;
 
     #[test_only]
-    use diem_std::debug;
-    #[test_only]
     use diem_std::table_with_length;
 
     friend diem_framework::block;
@@ -256,6 +254,9 @@ module diem_framework::randomness {
     /// NOTE: The uniformity is not perfect, but it can be proved that the bias is negligible.
     /// If you need perfect uniformity, consider implement your own via rejection sampling.
     public(friend) fun u8_range(min_incl: u8, max_excl: u8): u8 acquires PerBlockRandomness {
+        // let the caller decide how to handle
+        if (max_excl<= min_incl) { return 0 };
+
         let range = ((max_excl - min_incl) as u256);
         let sample = ((u256_integer_internal() % range) as u8);
 
@@ -294,8 +295,9 @@ module diem_framework::randomness {
     ///
     /// NOTE: The uniformity is not perfect, but it can be proved that the bias is negligible.
     /// If you need perfect uniformity, consider implement your own via rejection sampling.
-   public (friend) fun u64_range(min_incl: u64, max_excl: u64): u64 acquires PerBlockRandomness {
-        // event::emit_event(RandomnessGeneratedEvent {});
+   public(friend) fun u64_range(min_incl: u64, max_excl: u64): u64 acquires PerBlockRandomness {
+        // let the caller decide how to handle
+        if (max_excl<= min_incl) { return 0 };
 
         u64_range_internal(min_incl, max_excl)
     }
@@ -303,7 +305,6 @@ module diem_framework::randomness {
     fun u64_range_internal(min_incl: u64, max_excl: u64): u64 acquires PerBlockRandomness {
         let range = ((max_excl - min_incl) as u256);
         let sample = ((u256_integer_internal() % range) as u64);
-
         min_incl + sample
     }
 
@@ -457,8 +458,10 @@ module diem_framework::randomness {
         set_seed(x"0000000000000000000000000000000000000000000000000000000000000000");
         // Test cases should always have no bias for any randomness call.
         // assert!(is_unbiasable(), 0);
-        let num = u64_integer();
-        debug::print(&num);
+        let num1 = u64_integer();
+        let num2 = u64_integer();
+        assert!(num1 != num2, 7357001);
+
     }
 
     // #[test_only]

--- a/framework/libra-framework/sources/randomness.move
+++ b/framework/libra-framework/sources/randomness.move
@@ -29,6 +29,7 @@ module diem_framework::randomness {
     use std::vector;
     use diem_framework::system_addresses;
     use diem_framework::transaction_context;
+
     #[test_only]
     use diem_std::debug;
     #[test_only]
@@ -36,6 +37,7 @@ module diem_framework::randomness {
 
     friend diem_framework::block;
     friend ol_framework::musical_chairs;
+    friend ol_framework::sortition;
 
     const INIT_SEED: vector<u8> = b"all your base are belong to us";
 
@@ -292,7 +294,7 @@ module diem_framework::randomness {
     ///
     /// NOTE: The uniformity is not perfect, but it can be proved that the bias is negligible.
     /// If you need perfect uniformity, consider implement your own via rejection sampling.
-   fun u64_range(min_incl: u64, max_excl: u64): u64 acquires PerBlockRandomness {
+   public (friend) fun u64_range(min_incl: u64, max_excl: u64): u64 acquires PerBlockRandomness {
         // event::emit_event(RandomnessGeneratedEvent {});
 
         u64_range_internal(min_incl, max_excl)


### PR DESCRIPTION
[Don't merge WIP]
Validator auction in Proof of Fee, will have random assignment to the validator set, based on the the fee offered. This is an adjustment to consider the case where the validator set does not expand over many epochs, and the lowest bidder could attempt to manipulate the auction (for the benefit of all validators).  With this change the auction gives bidders the equivalent of a "ticket" to a "raffle". In this case outliers (bidding 0 in the auction), will result in very improbable admission.