### PR TITLE
Add basic container file and CI job

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       # make binaries which may be ahead of releases to use in CI jobs
       - "ci-bins*"
-      - "*" # DELETE ME
     tags: # run this also on release candidates
       - "[0-9]+.[0-9]+.[0-9]*"
 

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,48 @@
+name: build container
+on:
+  push:
+    branches:
+      # make binaries which may be ahead of releases to use in CI jobs
+      - "ci-bins*"
+      - "*" # DELETE ME
+    tags: # run this also on release candidates
+      - "[0-9]+.[0-9]+.[0-9]*"
+
+# Note: builds only Intel container at present
+
+jobs:
+  publish:
+    permissions: write-all
+    name: container-build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/libra-node
+          tags: |
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+
+      - name: Log in to Container Image Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./container/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CI_COMMIT_SHA=${{ github.sha }}

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,14 @@
+# Built from https://github.com/rust-lang/docker-rust
+# "latest" has a Debian base
+FROM rust:latest AS builder
+
+# Install build dependencies
+RUN apt update && apt install -y build-essential lld pkg-config libssl-dev libgmp-dev clang
+
+WORKDIR /usr/libra
+COPY . .
+RUN cargo build --release
+
+FROM ubuntu:latest
+
+COPY --from=builder /usr/libra/target/release /usr/local/bin/

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -11,4 +11,4 @@ RUN cargo build --release
 
 FROM ubuntu:latest
 
-COPY --from=builder /usr/libra/target/release /usr/local/bin/
+COPY --from=builder /usr/libra/target/release/libra /usr/libra/target/release/libra-* /usr/local/bin/


### PR DESCRIPTION
This PR adds a Containerfile (aka Dockerfile) that builds a simple container image based on Ubuntu containing the suite of release binaries. CI job is configured to build on tags and on the same ci-bins* branches used to build bare binaries.
At present the CI job only builds an Intel image. Should build for ARM ok on an ARM machine though. We can add
buildx/quemu support for cross-platform builds at a later date, or specify an ARM runner and a matrix. GH just added ARM runners so not sure yet which is the best approach.