### PR TITLE
Add missing CA certs package

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -10,5 +10,6 @@ COPY . .
 RUN cargo build --release
 
 FROM ubuntu:latest
+RUN apt update && apt install -y ca-certificates
 
 COPY --from=builder /usr/libra/target/release/libra /usr/libra/target/release/libra-* /usr/local/bin/


### PR DESCRIPTION
The `libra` binary depends on local CA certs which are not installed in the base Ubuntu container.