### PR TITLE
[ci] rustc provisionally pinned to 1.80.1

### DIFF
--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -27,7 +27,7 @@ runs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: 1.84.0
         override: true
 
     - name: install rustfmt clippy

--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -27,7 +27,7 @@ runs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.78.0
+        toolchain: 1.83.0
         override: true
 
     - name: install rustfmt clippy

--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -27,7 +27,7 @@ runs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.84.0
+        toolchain: 1.78.0
         override: true
 
     - name: install rustfmt clippy

--- a/.github/actions/build_env/action.yaml
+++ b/.github/actions/build_env/action.yaml
@@ -27,7 +27,8 @@ runs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.83.0
+        # Provisionally pinning version pre 1.81 sorting changes
+        toolchain: 1.80.1
         override: true
 
     - name: install rustfmt clippy

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -24,5 +24,11 @@ jobs:
           toolchain: ${{matrix.channel}}
           override: true
 
-      - name: debug build
-        run: cargo b -p libra
+      - name: does it build?
+        run: cargo r -p libra
+
+      - name: does move compile?
+        run: cargo r -p libra -- move test --package-dir ./framework/libra-framework
+
+      - name: does it prove move?
+        run: cargo r -p libra -- move prove --package-dir ./framework/move-stdlib

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -25,10 +25,12 @@ jobs:
           override: true
 
       - name: does it build?
-        run: cargo r -p libra
+        run: cargo r -p libra -- version
 
       - name: does move compile?
+        if: always()
         run: cargo r -p libra -- move test --package-dir ./framework/libra-framework
 
       - name: does it prove move?
+        if: always()
         run: cargo r -p libra -- move prove --package-dir ./framework/move-stdlib

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -1,23 +1,16 @@
+# testing future versions of rust
 name: rust-versions
 on:
   push:
-    tags: # only on releases, not RC, since we've tested already
-      - "[0-9]+.[0-9]+.[0-9]+"
-    branches: ["**"] # glob pattern to allow slash /
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    branches:
-      - "release**"
-      - "main**"
+    branches: ["ci-bins*"] # glob pattern to allow slash /
   schedule:
     - cron: "30 00 * * *"
 
-# TODO: use ci run matrix options
-
 jobs:
-  builds-stable:
+  builds:
+    strategy:
+      matrix:
+        channel: ["stable", "beta", "nightly"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,62 +21,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          override: true
-      - name: install rustfmt clippy
-        shell: bash
-        run: rustup component add rustfmt clippy
-
-      - name: clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --tests -- -D warnings
-
-  builds-beta:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: setup env
-        uses: ./.github/actions/build_env
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: beta
+          toolchain: ${{matrix.channel}}
           override: true
 
-      - name: install rustfmt clippy
-        shell: bash
-        run: rustup component add rustfmt clippy
-
-      - name: clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --tests -- -D warnings
-
-  builds-nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: setup env
-        uses: ./.github/actions/build_env
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-
-      - name: install rustfmt clippy
-        shell: bash
-        run: rustup component add rustfmt clippy
-
-      - name: clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --tests -- -D warnings
+      - name: debug build
+        run: cargo b -p libra

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,24 @@
   // target/debug/ol-genesis-tools --fork --output-path /opt/genesis_from_snapshot.blob --snapshot-path /Users/gsimsek/code/libra-main/ol/devnet/snapshot/state_ver_267.54ab`
   "configurations": [
     {
+      "name": "move prove stdlib",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": [
+          "build",
+          "-p",
+          "libra"
+        ],
+      },
+      "args": [
+        "move",
+        "prove",
+        "./framework/move-stdlib",
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
       "name": "restore-epoch",
       "type": "lldb",
       "request": "launch",

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -108,7 +108,8 @@ fn main() -> anyhow::Result<()> {
                     Some(Sub::Version) => {
                         println!("LIBRA VERSION {}", env!("CARGO_PKG_VERSION"));
                         println!("build timestamp: {}", env!("VERGEN_BUILD_TIMESTAMP"));
-                        println!("rustc version: {}", env!("VERGEN_RUSTC_SEMVER"));
+                        // TODO:
+                        // println!("rustc version: {}", env!("VERGEN_RUSTC_SEMVER"));
                         println!("git branch: {}", env!("VERGEN_GIT_BRANCH"));
                         println!("git SHA: {}", env!("VERGEN_GIT_SHA"));
                         println!(


### PR DESCRIPTION
Rust 1.81.1 introduces a panic in the prover, which previously was benign.
See: https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#new-sort-implementations
Requires updates to diem boogie backend  