### PR TITLE
[move] lower threshold of validator competition

### DIFF
--- a/framework/drop-user-tools/last_goodbye.test.move
+++ b/framework/drop-user-tools/last_goodbye.test.move
@@ -44,16 +44,5 @@ module ol_framework::test_last_goodbye {
 
     mock::trigger_epoch(&framework);
 
-    // let _vals_post = stake::get_current_validators();
-
-    // assert!(epoch_boundary::get_reconfig_success(), 7357001);
-
-    // // all validators were compliant, should be +1 of the 10 vals
-    // assert!(epoch_boundary::get_seats_offered() == 11, 7357002);
-
-    // // all vals had winning bids, but it was less than the seats on offer
-    // assert!(vector::length(&epoch_boundary::get_auction_winners()) == 10, 7357003);
-    // // all of the auction winners became the validators ulitmately
-    // assert!(vector::length(&epoch_boundary::get_actual_vals()) == 10, 7357004);
   }
 }

--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -534,8 +534,13 @@ module diem_framework::epoch_boundary {
   }
 
   #[view]
-  public fun get_seats_offered():u64 acquires BoundaryStatus {
+  public fun get_max_seats_offered():u64 acquires BoundaryStatus {
     borrow_global<BoundaryStatus>(@ol_framework).incoming_seats_offered
+  }
+
+  #[view]
+  public fun get_filled_seats():u64 acquires BoundaryStatus {
+    borrow_global<BoundaryStatus>(@ol_framework).incoming_filled_seats
   }
 
   #[test_only]

--- a/framework/libra-framework/sources/ol_sources/proof_of_fee.move
+++ b/framework/libra-framework/sources/ol_sources/proof_of_fee.move
@@ -332,17 +332,14 @@ module ol_framework::proof_of_fee {
   public fun calculate_min_vouches_required(set_size: u64): u64 {
     let required = globals::get_validator_vouch_threshold();
 
-    // TODO: set a features switch here
-    //if (false) {
-      if (set_size > VAL_BOOT_UP_THRESHOLD) {
-        // dynamically increase the amount of social proofing as the
-        // validator set increases
-        required = math64::min(
-          (set_size / 10) + 1, // formula to get the min vouches required after bootup
-          globals::get_max_vouches_per_validator() - VOUCH_MARGIN
-        );
-      };
-    //};
+    if (set_size > 21) {
+      // dynamically increase the amount of social proofing as the
+      // validator set increases
+      required = math64::min(
+        (set_size / 10) + 1, // formula to get the min vouches required after bootup
+        globals::get_max_vouches_per_validator() - VOUCH_MARGIN
+      );
+    };
 
     required
   }

--- a/framework/libra-framework/sources/ol_sources/proof_of_fee.move
+++ b/framework/libra-framework/sources/ol_sources/proof_of_fee.move
@@ -23,7 +23,7 @@ module ol_framework::proof_of_fee {
   use ol_framework::slow_wallet;
   use ol_framework::epoch_helper;
   use ol_framework::address_utils;
-  //use diem_std::debug::print;
+  use diem_std::debug::print;
 
   friend diem_framework::genesis;
   friend ol_framework::epoch_boundary;
@@ -37,12 +37,12 @@ module ol_framework::proof_of_fee {
   const GENESIS_BASELINE_REWARD: u64 = 1_000_000;
   /// Number of vals needed before PoF becomes competitive for
   /// performant nodes as well
-  const VAL_BOOT_UP_THRESHOLD: u64 = 21;
+  const VAL_BOOT_UP_THRESHOLD: u64 = 4;
   /// This figure is experimental and a different percentage may be finalized
   /// after some experience in the wild. Additionally it could be dynamic
   /// based on another function or simply randomized within a range
   /// (as originally proposed in this feature request)
-  const PCT_REDUCTION_FOR_COMPETITION: u64 = 10; // 10%
+  const PCT_COMPETITIVENESS: u64 = 10; // 10%
   /// Upper bound threshold for bid percentages.
   const BID_UPPER_BOUND: u64 = 0950; // 95%
   /// Lower bound threshold for bid percentages.
@@ -163,7 +163,7 @@ module ol_framework::proof_of_fee {
   public(friend) fun end_epoch(
     vm: &signer,
     outgoing_compliant_set: &vector<address>,
-    mc_set_size: u64 // musical chairs set size suggestion
+    max_recommended_size: u64 // musical chairs set size suggestion
   ): (vector<address>, vector<address>, vector<address>, u64) acquires ProofOfFeeAuction, ConsensusReward {
     system_addresses::assert_ol(vm);
 
@@ -172,10 +172,9 @@ module ol_framework::proof_of_fee {
 
     // Calculate the final set size considering the number of compliant validators,
     // number of qualified bidders, and musical chairs set size suggestion
-    let final_set_size = calculate_final_set_size(
-      vector::length(outgoing_compliant_set),
+    let final_set_size = competitive_set_size(
       vector::length(&only_qualified_bidders),
-      mc_set_size);
+      max_recommended_size);
 
     // This is the core of the mechanism, the uniform price auction
     // the winners of the auction will be the validator set.
@@ -207,28 +206,37 @@ module ol_framework::proof_of_fee {
   // If we have more qualified bidders than the threshold, we should limit the final set size
   // to 90% of the qualified bidders to ensure that vals will compete for seats.
 
-  fun calculate_final_set_size(
-    outgoing_compliant: u64,
+  fun competitive_set_size(
     qualified_bidders: u64,
-    mc_set_size: u64 // musical chairs set size suggestion
+    max_recommended_size: u64 // musical chairs set size suggestion
   ): u64 {
-    // 1. Boot Up
-    if (
-      outgoing_compliant < VAL_BOOT_UP_THRESHOLD &&
-      outgoing_compliant > 2
-    ) {
-      return math64::min(outgoing_compliant + (outgoing_compliant/2 - 1), VAL_BOOT_UP_THRESHOLD)
+    print(&max_recommended_size);
+    // Belt and suspenders
+    // if the musical chairs suggestion is below 4, the practical minimum for BFT, then return 4.
+    if (max_recommended_size < VAL_BOOT_UP_THRESHOLD) {
+      return VAL_BOOT_UP_THRESHOLD
     };
 
-    // 2. Competitive Set
-    if (mc_set_size >= VAL_BOOT_UP_THRESHOLD && qualified_bidders >= VAL_BOOT_UP_THRESHOLD) {
-      let seats_to_remove = qualified_bidders * PCT_REDUCTION_FOR_COMPETITION / 100;
+    // Ensure competitiveness
+    // We want to target there being x% more bidders than seats available.
+    //
+    // If the count of bidders is LESS THAN OR EQUAL recommended set size,
+    // then it's not a competitive set, and we should DECREASE the set size
+    // (according to the max recommendation from musical_chairs)
+    let competitive_threshold = max_recommended_size * (1 + (PCT_COMPETITIVENESS/100));
+    print(&competitive_threshold);
+
+    if (qualified_bidders <= competitive_threshold) {
+      print(&@0x12);
+      print(&qualified_bidders);
+      let seats_to_remove = (qualified_bidders * PCT_COMPETITIVENESS) / 100;
+      print(&seats_to_remove);
       let max_qualified = qualified_bidders - seats_to_remove;
-      // do note increase beyond musical chairs suggestion and competitive set size
-      return math64::min(max_qualified, mc_set_size)
+      // check that we DO NOT increase beyond musical chairs recommendation OR competitive set size
+      return math64::min(max_qualified, max_recommended_size)
     };
 
-    mc_set_size
+    max_recommended_size
   }
 
   /// The fees are charged seperate from the auction and seating loop
@@ -1166,138 +1174,41 @@ module ol_framework::proof_of_fee {
   // Calculate Final Set Size tests
 
   #[test]
-  fun test_calculate_final_set_size_boot_up_happy_day() {
-    // Happy Day: test complete boot up with plenty qualified bidders over multiple epochs
-    // having validators always compliant
+  fun test_competitive_set_size_math() {
+    // Testing we are making the validator set competitive
+    // and checking for failure cases.
 
-    // Epoch 1
-    let outgoing_compliant = 0;
+    // not competitive
     let qualified_bidders = 100;
-    let mc_set_size = 4;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
+    let max_recommended_size = 100;
+    let result = competitive_set_size(qualified_bidders, max_recommended_size);
+    diem_std::debug::print(&result);
+    assert!(result == 90, 7357025);
+
+
+    // happy case
+    // many more bidders than the lowest threshold
+    let qualified_bidders = 100;
+    let max_recommended_size = 50;
+    let result = competitive_set_size(qualified_bidders, max_recommended_size);
+    assert!(result == 50, 7357023);
+
+    // near failure case
+    // many more bidders than the lowest threshold
+    let qualified_bidders = 100;
+    let max_recommended_size = 4;
+    let result = competitive_set_size(qualified_bidders, max_recommended_size);
     assert!(result == 4, 7357023);
 
-    // Epoch 2
-    outgoing_compliant = 4;
-    mc_set_size = 5;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 4 + (4/2 - 1) = 5
-    assert!(result == 5, 7357024);
-
-    // Epoch 3
-    outgoing_compliant = 5;
-    mc_set_size = 6;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 5 + (5/2 - 1) = 6
-    assert!(result == 6, 7357025);
-
-    // Epoch 4
-    outgoing_compliant = 6;
-    mc_set_size = 7;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 6 + (6/2 - 1) = 8
-    assert!(result == 8, 7357026);
-
-    // Epoch 5
-    outgoing_compliant = 8;
-    mc_set_size = 9;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 8 + (8/2 - 1) = 11
-    assert!(result == 11, 7357027);
-
-    // Epoch 6
-    outgoing_compliant = 11;
-    mc_set_size = 12;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 11 + (11/2 - 1) = 15
-    assert!(result == 15, 7357028);
-
-    // Epoch 6
-    outgoing_compliant = 15;
-    mc_set_size = 16;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // 15 + (15/2 - 1) = 21
-    // min (21, 21)
-    assert!(result == 21, 7357028);
-
-    // Epoch 7 - Boot up ended
-    outgoing_compliant = 21;
-    mc_set_size = 22;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // min(22, 100*90%) = 22
-    assert!(result == 22, 7357029);
-  }
-
-  #[test]
-  fun test_calculate_final_set_size_boot_up_threshold() {
+    // catch failure mode, somehow recommended size is below 4
     let qualified_bidders = 100;
-
-    // Test boot up increases maximum set size to 21
-    let outgoing_compliant = 20;
-    let mc_set_size = 20;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    assert!(result == 21, 7357030);
-
-    // Test set size stays at 21
-    outgoing_compliant = 21;
-    mc_set_size = 21;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    assert!(result == 21, 7357030);
-
-    // Test set size increases to 22
-    outgoing_compliant = 22;
-    mc_set_size = 22;
-    result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // min (22, 100*90%) = 22
-    assert!(result == 22, 7357030);
+    let max_recommended_size = 2;
+    let result = competitive_set_size(qualified_bidders, max_recommended_size);
+    assert!(result == 4, 7357024);
   }
 
-  #[test]
-  fun test_calculate_final_set_size_competitive_set_no_changes() {
-    let outgoing_compliant = 21;
-    let qualified_bidders = 40;
-    let mc_set_size = 21;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    assert!(result == 21, 7357030);
-  }
-
-  #[test]
-  fun test_calculate_final_set_size_competitive_set_increases() {
-    let outgoing_compliant = 30;
-    let qualified_bidders = 40;
-    let mc_set_size = 31;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    assert!(result == 31, 7357030);
-  }
-
-  #[test]
-  fun test_calculate_final_set_size_competitive_set_decreases() {
-    let outgoing_compliant = 50;
-    let qualified_bidders = 50;
-    let mc_set_size = 50;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    assert!(result == 45, 7357030);
-  }
-
-  #[test]
-  fun test_calculate_final_set_size_competitive_set_decreases_to_boot_up() {
-    let outgoing_compliant = 21;
-    let qualified_bidders = 21;
-    let mc_set_size = 21;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // min(21, 21*90%) = 19
-    assert!(result == 19, 7357030);
-
-    let outgoing_compliant = 21;
-    let qualified_bidders = 20;
-    let mc_set_size = 21;
-    let result = calculate_final_set_size(outgoing_compliant, qualified_bidders, mc_set_size);
-    // mc value
-    assert!(result == 21, 7357030);
-  }
 
   // Tests for calculate_reward_adjustment
-
   #[test]
   public fun cra_nominal_reward_zero() {
     let median_history = vector::empty<u64>();

--- a/framework/libra-framework/sources/ol_sources/tests/boundary.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/boundary.test.move
@@ -86,21 +86,26 @@ module ol_framework::test_boundary {
 
     // all validators were compliant, should be +1 of the 10 vals
     assert!(epoch_boundary::get_seats_offered() == 11, 7357002);
+
     // all vals had winning bids, but it was less than the seats on offer
-    assert!(vector::length(&epoch_boundary::get_auction_winners()) == 10, 7357003);
-    // all of the auction winners became the validators ulitmately
-    assert!(vector::length(&epoch_boundary::get_actual_vals()) == 10, 7357004);
+    let winners = epoch_boundary::get_auction_winners();
+    assert!(vector::length(&winners) == 9, 7357003);
+    // all of the auction winners became the validators ultimately
+    assert!(vector::length(&epoch_boundary::get_actual_vals()) == 9, 7357004);
+
 
     // check vals rewards received and bid fees collected
-    // balance + reward - fee = 500_000 + 1_000_000 - 10_000 = 1_490_000
-    vector::for_each(vals, |addr| {
+    // NOTE the clearing bid in this example is not the last validator, but the 9th = 2_000
+    // balance + reward - fee = 500_000 + 1_000_000 - 2_000 = 1_498_000
+    vector::for_each(winners, |addr| {
       let (_unlocked, total) = ol_account::balance(addr);
-      assert!(total == 1_499_000, 7357005);
+      assert!(total == 1_498_000, 7357005);
     });
 
     // check subsidy for new rewards and fees collected
-    // fees collected = 10 * 1_000_000 + 10 * 1_000 = 10_010_000
-    assert!(transaction_fee::system_fees_collected() == 10_010_000, 7357006);
+    // validators = 9
+    // fees collected = 9 * 1_000_000 + 9 * 2_000 = 9_018_000
+    assert!(transaction_fee::system_fees_collected() == 9018000, 7357006);
   }
 
   // #[test(root = @ol_framework, alice = @0x1000a,  marlon_rando = @0x12345)]
@@ -289,7 +294,7 @@ module ol_framework::test_boundary {
     // NOTE: now MARLON is INCLUDED in this, and we filled all the seats on offer.
     // all vals had winning bids, but it was less than the seats on offer
     assert!(vector::length(&epoch_boundary::get_auction_winners()) == 10, 7357003);
-    // all of the auction winners became the validators ulitmately
+    // all of the auction winners became the validators ultimately
     assert!(vector::length(&epoch_boundary::get_actual_vals()) == 10, 7357004);
   }
 

--- a/framework/libra-framework/sources/ol_sources/tests/boundary.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/boundary.test.move
@@ -10,7 +10,7 @@ module ol_framework::test_boundary {
   use diem_framework::diem_governance;
   use diem_framework::transaction_fee;
   use diem_framework::account;
-  use ol_framework::burn;
+  // use ol_framework::burn;
   use ol_framework::mock;
   use ol_framework::proof_of_fee;
   use ol_framework::jail;
@@ -100,14 +100,116 @@ module ol_framework::test_boundary {
 
     // check subsidy for new rewards and fees collected
     // fees collected = 10 * 1_000_000 + 10 * 1_000 = 10_010_000
-    print(&transaction_fee::system_fees_collected());
     assert!(transaction_fee::system_fees_collected() == 10_010_000, 7357006);
   }
 
+  // #[test(root = @ol_framework, alice = @0x1000a,  marlon_rando = @0x12345)]
+  // fun e2e_add_validator_happy(root: signer, alice: signer, marlon_rando: signer) {
+  //   let initial_vals = common_test_setup(&root);
+
+  //   // generate credentials for validator registration
+  //   ol_account::transfer(&alice, @0x12345, 200000);
+  //   let (_sk, pk, pop) = stake::generate_identity();
+  //   let pk_bytes = bls12381::public_key_to_bytes(&pk);
+  //   let pop_bytes = bls12381::proof_of_possession_to_bytes(&pop);
+  //   validator_universe::register_validator(&marlon_rando, pk_bytes, pop_bytes, b"123", b"abc");
+
+  //   // MARLON PAYS THE BID
+  //   let vals = validator_universe::get_eligible_validators();
+  //   assert!(vector::length(&vals) == 11, 7357001);
+
+  //   mock::mock_bids(&vals);
+
+  //   // MARLON HAS MANY FRIENDS
+  //   vouch::test_set_buddies(@0x12345, vals);
+
+  //   let (errs, _pass) = proof_of_fee::audit_qualification(@0x12345);
+  //   assert!(vector::length(&errs) == 0, 7357002);
+
+  //   // get initial vals balance
+  //   let balances = vector::map(initial_vals, |addr| {
+  //     let (_unlocked, total) = ol_account::balance(addr);
+  //     total
+  //   });
+
+  //   mock::trigger_epoch(&root);
+
+  //   assert!(epoch_boundary::get_reconfig_success(), 7357003);
+
+  //   // musical chairs recommended 11 seats BUT...
+  //   assert!(epoch_boundary::get_seats_offered() == 11, 7357004);
+
+  //   // there were only 11 bidders for the 11 offered, which is not competitive enough
+  //   assert!(epoch_boundary::get_qualified_bidders() == 11, 7357004);
+
+  //   // NOTE: now MARLON is INCLUDED in this, and we filled all the seats on offer.
+  //   // all vals had winning bids, but it was less than the seats on offer
+  //   let win = epoch_boundary::get_auction_winners();
+  //   // print(&vector::length(&win));
+
+
+  //   assert!(vector::length(&win) == 10, 7357005);
+
+  //   // // all of the auction winners became the validators ulitmately
+  //   // assert!(vector::length(&epoch_boundary::get_actual_vals()) == 11, 7357006);
+
+  //   // // check initial vals rewards received and bid fees collected
+  //   // // previous balance = current - reward + fee
+  //   // let i = 0;
+  //   // while (i < vector::length(&initial_vals)) {
+  //   //   let (_unlocked, current) = ol_account::balance(*vector::borrow(&initial_vals, i));
+  //   //   let previous = *vector::borrow(&balances, i);
+  //   //   assert!(current == (previous + 1_000_000 - 1_000), 7357007);
+  //   //   i = i + 1;
+  //   // };
+
+  //   // // check Marlon's balance: 200_000 - 1_000 = 199_000
+  //   // let (_unlocked, marlon_balance) = ol_account::balance(@0x12345);
+  //   // assert!(marlon_balance == 199_000, 7357008);
+
+  //   // // check subsidy for new rewards and fees collected
+  //   // // fees collected = 11 * 1_000_000 + 11 * 1_000 = 11_011_000
+  //   // assert!(transaction_fee::system_fees_collected() == 11_011_000, 7357009);
+
+  //   // // another epoch and everyone is compliant as well
+  //   // mock::mock_all_vals_good_performance(&root);
+  //   // mock::trigger_epoch(&root);
+
+  //   // assert!(epoch_boundary::get_seats_offered() == 12, 7357010);
+  //   // assert!(vector::length(&epoch_boundary::get_actual_vals()) == 11, 7357011);
+
+  //   // // check initial vals rewards received and bid fees collected
+  //   // // previous balance = current - 2*reward + 2*fee
+  //   // let i = 0;
+  //   // while (i < vector::length(&initial_vals)) {
+  //   //   let (_unlocked, current) = ol_account::balance(*vector::borrow(&initial_vals, i));
+  //   //   let previous = *vector::borrow(&balances, i);
+  //   //   assert!(current == (previous + 2_000_000 - 2_000), 7357012);
+  //   //   i = i + 1;
+  //   // };
+
+  //   // // check Marlon's balance: 200_000 + 1_000_000 - 2_000 = 1_198_000
+  //   // let (_unlocked, marlon_balance) = ol_account::balance(@0x12345);
+  //   // assert!(marlon_balance == 1_198_000, 7357013);
+
+  //   // // CHECK BURNT FEES
+
+  //   // // prepare clean epoch
+  //   // mock::trigger_epoch(&root);
+
+  //   // let (before, _) = burn::get_lifetime_tracker();
+
+  //   // mock::trigger_epoch(&root);
+
+  //   // // check that only the entry fee sum is being burnt
+  //   // let (after,_) = burn::get_lifetime_tracker();
+  //   // assert!(after - before == 11_000_000, 7357014); // scale 1_000
+  // }
+
 
   #[test(root = @ol_framework, alice = @0x1000a,  marlon_rando = @0x12345)]
-  fun e2e_add_validator_happy(root: signer, alice: signer, marlon_rando: signer) {
-    let initial_vals = common_test_setup(&root);
+  fun e2e_competitive_set(root: signer, alice: signer, marlon_rando: signer) {
+    let _initial_vals = common_test_setup(&root);
 
     // generate credentials for validator registration
     ol_account::transfer(&alice, @0x12345, 200000);
@@ -128,75 +230,37 @@ module ol_framework::test_boundary {
     let (errs, _pass) = proof_of_fee::audit_qualification(@0x12345);
     assert!(vector::length(&errs) == 0, 7357002);
 
-    // get initial vals balance
-    let balances = vector::map(initial_vals, |addr| {
-      let (_unlocked, total) = ol_account::balance(addr);
-      total
-    });
+    let (_unlocked, bob_bal) = ol_account::balance(@0x1000b);
+    assert!(bob_bal == 500000, 737001);
+    let (_unlocked, marlon_bal) = ol_account::balance(@0x12345);
+    assert!(marlon_bal == 200000, 737001);
+
 
     mock::trigger_epoch(&root);
 
     assert!(epoch_boundary::get_reconfig_success(), 7357003);
 
-    // all validators were compliant, should be +1 of the 10 vals
+    // musical chairs recommended 11 seats BUT...
     assert!(epoch_boundary::get_seats_offered() == 11, 7357004);
-    // NOTE: now MARLON is INCLUDED in this, and we filled all the seats on offer.
-    // all vals had winning bids, but it was less than the seats on offer
-    assert!(vector::length(&epoch_boundary::get_auction_winners()) == 11, 7357005);
-    // all of the auction winners became the validators ulitmately
-    assert!(vector::length(&epoch_boundary::get_actual_vals()) == 11, 7357006);
 
-    // check initial vals rewards received and bid fees collected
-    // previous balance = current - reward + fee
-    let i = 0;
-    while (i < vector::length(&initial_vals)) {
-      let (_unlocked, current) = ol_account::balance(*vector::borrow(&initial_vals, i));
-      let previous = *vector::borrow(&balances, i);
-      assert!(current == (previous + 1_000_000 - 1_000), 7357007);
-      i = i + 1;
-    };
+    // there were only 11 bidders for the 11 offered, which is not competitive enough
+    assert!(vector::length(&epoch_boundary::get_qualified_bidders()) == 11, 7357004);
 
-    // check Marlon's balance: 200_000 - 1_000 = 199_000
-    let (_unlocked, marlon_balance) = ol_account::balance(@0x12345);
-    assert!(marlon_balance == 199_000, 7357008);
+    assert!(vector::length(&epoch_boundary::get_auction_winners()) == 10, 7357005);
 
-    // check subsidy for new rewards and fees collected
-    // fees collected = 11 * 1_000_000 + 11 * 1_000 = 11_011_000
-    assert!(transaction_fee::system_fees_collected() == 11_011_000, 7357009);
+    // in this case the clearing price was not the last (11th bid), but the 10th
+    let auction_fee = 2_000;
 
-    // another epoch and everyone is compliant as well
-    mock::mock_all_vals_good_performance(&root);
-    mock::trigger_epoch(&root);
+    print(&auction_fee);
+    let (_unlocked, bob_bal_now) = ol_account::balance(@0x1000b);
+    print(&bob_bal_now);
+    assert!(bob_bal_now == bob_bal + 1_000_000 - 2_000, 737001);
 
-    assert!(epoch_boundary::get_seats_offered() == 12, 7357010);
-    assert!(vector::length(&epoch_boundary::get_actual_vals()) == 11, 7357011);
+    let (_unlocked, marlon_bal_now) = ol_account::balance(@0x12345);
+    print(&marlon_bal_now);
+    // MARLON just got seated (he outbid others), but he did not receive a reward from previous epoch
+    assert!(marlon_bal_now == marlon_bal - 2_000, 737001);
 
-    // check initial vals rewards received and bid fees collected
-    // previous balance = current - 2*reward + 2*fee
-    let i = 0;
-    while (i < vector::length(&initial_vals)) {
-      let (_unlocked, current) = ol_account::balance(*vector::borrow(&initial_vals, i));
-      let previous = *vector::borrow(&balances, i);
-      assert!(current == (previous + 2_000_000 - 2_000), 7357012);
-      i = i + 1;
-    };
-
-    // check Marlon's balance: 200_000 + 1_000_000 - 2_000 = 1_198_000
-    let (_unlocked, marlon_balance) = ol_account::balance(@0x12345);
-    assert!(marlon_balance == 1_198_000, 7357013);
-
-    // CHECK BURNT FEES
-
-    // prepare clean epoch
-    mock::trigger_epoch(&root);
-
-    let (before, _) = burn::get_lifetime_tracker();
-
-    mock::trigger_epoch(&root);
-
-    // check that only the entry fee sum is being burnt
-    let (after,_) = burn::get_lifetime_tracker();
-    assert!(after - before == 11_000_000, 7357014); // scale 1_000
   }
 
   #[test(root = @ol_framework, alice = @0x1000a,  marlon_rando = @0x12345)]


### PR DESCRIPTION
During the proof-of-fee v1 experiment, validator competitive bidding was set to apply to validator sets larger than 21. This proposal removes that threshold, and all validator sets above minimal viable (four validators) will have the competitive bidding enabled.