### PR TITLE
[vouch] patch vouch walk and re-authentication workflows

### DIFF
--- a/framework/libra-framework/sources/ol_sources/donor_voice_governance.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_governance.move
@@ -230,14 +230,6 @@ module ol_framework::donor_voice_governance {
     ): guid::ID acquires Governance {
       let data = Reauth {};
 
-      // check if this creates a duplicate proposal
-      let dv_account = account::get_guid_capability_address(cap);
-      let state = borrow_global_mut<Governance<TurnoutTally<Reauth>>>(dv_account);
-      let pending_list = ballot::get_list_ballots_by_enum_mut(&mut state.tracker, ballot::get_pending_enum());
-      // there should only be one pending reauth at a given time
-      assert!(vector::length(pending_list) == 1, error::invalid_argument(EDUPLICATE_PROPOSAL));
-
-
       propose_gov<Reauth>(cap, data, DEFAULT_CW_REAUTH_DAYS)
     }
 

--- a/framework/libra-framework/sources/ol_sources/donor_voice_governance.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_governance.move
@@ -350,8 +350,17 @@ module ol_framework::donor_voice_governance {
     }
 
     #[view]
-    // returns a tuple of the (percent approval, turnout percent, threshold needed to pass)
-    public fun get_reauth_tally(dv_account: address): (u64, u64, u64) acquires Governance {
+    /// Returns the details of a vote result as a tuple.
+    ///
+    /// # Returns
+    ///
+    /// * `(percent_approval, turnout_percent, threshold_needed_to_pass, epoch_deadline, minimum_turnout_required)`
+    ///   - `percent_approval`: The percentage of votes that approved the proposal.
+    ///   - `turnout_percent`: The percentage of eligible voters who participated.
+    ///   - `threshold_needed_to_pass`: The minimum approval percentage required for the proposal to pass.
+    ///   - `epoch_deadline`: The epoch by which voting must be completed.
+    ///   - `minimum_turnout_required`: The minimum percentage of eligible voters that must participate for the vote to be valid.
+    public fun get_reauth_tally(dv_account: address): (u64, u64, u64, u64, u64) acquires Governance {
       let state = borrow_global<Governance<TurnoutTally<Reauth>>>(dv_account);
       let pending_list = ballot::get_list_ballots_by_enum(&state.tracker, ballot::get_pending_enum());
 
@@ -362,8 +371,10 @@ module ol_framework::donor_voice_governance {
       let approval_pct = turnout_tally::get_current_ballot_approval(tally);
       let turnout_pct = turnout_tally::get_current_ballot_participation(tally);
       let current_threshold = turnout_tally::get_current_threshold_required(tally);
+      let epoch_deadline = turnout_tally::get_expiration_epoch(tally);
+      let minimum_turnout = turnout_tally::get_minimum_turnout(tally);
 
-      (approval_pct, turnout_pct, current_threshold)
+      (approval_pct, turnout_pct, current_threshold, epoch_deadline, minimum_turnout)
     }
 
     #[view]

--- a/framework/libra-framework/sources/ol_sources/donor_voice_reauth.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_reauth.move
@@ -17,13 +17,11 @@ module ol_framework::donor_voice_reauth {
     use std::timestamp;
     use diem_framework::account;
     use ol_framework::activity;
-    use ol_framework::reauthorization;
 
-    // use std::debug::print;
-
+    friend ol_framework::community_wallet_advance;
     friend ol_framework::donor_voice_txs;
     friend ol_framework::donor_voice_governance;
-    friend ol_framework::community_wallet_advance;
+    friend ol_framework::reauthorization;
 
     #[test_only]
     friend ol_framework::test_community_wallet;
@@ -82,8 +80,9 @@ module ol_framework::donor_voice_reauth {
     // TODO: add more boundaries with a capability type
     /// internal function to remove authorization because of an
     /// automated policy (delinquency, or payment vetoes)
-    public(friend) fun set_requires_reauth(user: &signer, dv_account: address) acquires DonorAuthorized {
-      reauthorization::assert_v8_authorized(signer::address_of(user));
+    public(friend) fun set_requires_reauth(_user: &signer, dv_account: address) acquires DonorAuthorized {
+      // TODO: circular dependency with reauthorization
+      // reauthorization::assert_v8_authorized(signer::address_of(user));
       let state = borrow_global_mut<DonorAuthorized>(dv_account);
       state.reauth_required = true;
     }
@@ -127,7 +126,7 @@ module ol_framework::donor_voice_reauth {
         one_year_ago = now - SECONDS_IN_YEAR
       };
 
-      if (latest_tx > one_year_ago) {
+      if (latest_tx >= one_year_ago) {
         return true
       };
       false

--- a/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
@@ -935,7 +935,7 @@ module ol_framework::donor_voice_txs {
       // if the reauthorization is already proposed, then we can vote on it.
       reauthorize_handler(donor, multisig_address);
     } else {
-      // go a head and propose it
+      // go ahead and propose it
       propose_reauthorization_impl(donor, multisig_address);
     }
   }

--- a/framework/libra-framework/sources/ol_sources/mock.move
+++ b/framework/libra-framework/sources/ol_sources/mock.move
@@ -594,8 +594,9 @@ module ol_framework::mock {
     assert!(score == vector::length(&received_vouches) * 50, 7357002);
 
     let remaining = vouch_limits::get_vouch_limit(alice);
-    // received 9 vouches, and has given 9, so there's one extra
-    assert!(remaining == 1, 7357003);
+    // received 9 vouches, and has given 9, and since is root
+    // has a max of 20.
+    assert!(remaining == 11, 7357003);
   }
 
   #[test_only]

--- a/framework/libra-framework/sources/ol_sources/ol_account.move
+++ b/framework/libra-framework/sources/ol_sources/ol_account.move
@@ -231,8 +231,8 @@ module ol_framework::ol_account {
     //   lookup_addr == signer::address_of(&new_signer),
     //   error::invalid_state(ECANT_MATCH_ADDRESS_IN_LOOKUP)
     // );
-    coin::register<LibraCoin>(&new_signer);
-    maybe_init_burn_tracker(&new_signer);
+    init_from_sig_impl(framework, &new_signer);
+
     new_signer
   }
   /// Migrate the tracker. Depends on the BurnTracker having been initialized

--- a/framework/libra-framework/sources/ol_sources/reauthorization.move
+++ b/framework/libra-framework/sources/ol_sources/reauthorization.move
@@ -3,6 +3,7 @@ module ol_framework::reauthorization {
     use std::error;
     use ol_framework::activity;
     use ol_framework::community_wallet;
+    use ol_framework::donor_voice_reauth;
     use ol_framework::founder;
 
 
@@ -22,8 +23,7 @@ module ol_framework::reauthorization {
       let is_cw = community_wallet::is_init(account);
 
       if (is_cw) {
-        // TODO:
-        assert!(true, error::invalid_state(ECOMMUNITY_WALLET_HAS_NO_AUTH));
+        donor_voice_reauth::assert_authorized(account)
       };
       // case 1: not migrated from V7
       if(!founder && !is_cw) {
@@ -35,7 +35,8 @@ module ol_framework::reauthorization {
 
     #[view]
     public fun is_v8_authorized(account: address): bool {
-      // case 1: has activity struct, and not founder, or community wallet
+      // case 1: user onboarded since v8 started
+      // has activity struct, and not founder, or community wallet
       if (
         activity::has_ever_been_touched(account) &&
         !founder::is_founder(account) &&
@@ -55,8 +56,7 @@ module ol_framework::reauthorization {
       };
       // case 3: a community wallet which was reauthorized
       if(community_wallet::is_init(account)) {
-        // TODO: merge with reauthorization PR
-        return true
+        return donor_voice_reauth::is_authorized(account)
       };
 
       false

--- a/framework/libra-framework/sources/ol_sources/tests/community_wallet.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/community_wallet.test.move
@@ -6,6 +6,7 @@
     use ol_framework::community_wallet_init;
     use ol_framework::donor_voice_txs;
     use ol_framework::multi_action;
+    use diem_framework::timestamp;
     use ol_framework::mock;
     use ol_framework::ol_account;
     use ol_framework::ancestry;
@@ -56,9 +57,9 @@
         community_wallet_init::migrate_community_wallet_account(root, community);
 
         // verify correct migration of community wallet
-        assert!(community_wallet::is_init(community_wallet_address), 7357001); //TODO: find appropriate error codes
+        assert!(community_wallet::is_init(community_wallet_address), 7357001);
 
-        // the usual initialization should fix the structs
+        // the usual initialization will start the process
         community_wallet_init::init_community(community, auths, 2);
         // confirm the bug
         assert!(!multisig_account::is_multisig(community_wallet_address), 7357002);
@@ -130,6 +131,9 @@
         community_wallet_init::finalize_and_cage(alice, 2);
 
         donor_voice_reauth::assert_authorized(alice_comm_wallet_addr);
+
+        // fast forward timestamp six years in seconds
+        timestamp::fast_forward_seconds(6 * 365 * 24 * 60 * 60);
 
         ////////
         // NO CALL TO REAUTHORIZE THE COMMUNITY WALLET

--- a/framework/libra-framework/sources/ol_sources/tests/vouch_validator.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/vouch_validator.test.move
@@ -196,17 +196,17 @@ module ol_framework::test_validator_vouch {
   }
 
   #[test(root = @ol_framework, alice = @0x1000a)]
-  #[expected_failure(abort_code = 196618, location = ol_framework::vouch_limits)]
+  #[expected_failure(abort_code = 196617, location = ol_framework::vouch_limits)]
   fun vouch_over_max_received(root: &signer, alice: &signer) {
     // create vals without vouches
     mock::genesis_n_vals(root, 2);
     // mock::create_validator_accounts(root, 2, true);
     vouch::set_vouch_price(root, 0);
 
-    let users = mock::create_test_end_users(root, 10, 0);
+    let users = mock::create_test_end_users(root, 22, 0);
 
     let i = 0;
-    while (i < 10) {
+    while (i < vector::length(&users)) {
       let sig = vector::borrow(&users, i);
       // init vouch for 10 validators
       vouch::init(sig);

--- a/framework/libra-framework/sources/ol_sources/vouch_lib/page_rank_lazy.move
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/page_rank_lazy.move
@@ -125,7 +125,9 @@ module ol_framework::page_rank_lazy {
         max_depth: u64,
         current_power: u64
     ): u64 {
-        assert!(vouch::is_init(current), error::invalid_state(ENOT_INITIALIZED));
+        if(!vouch::is_init(current)) {
+            return 0
+        };
 
         // Great, we found the target!
         // then we get to return the power

--- a/framework/libra-framework/sources/ol_sources/vouch_lib/vouch_limits.move
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/vouch_limits.move
@@ -65,20 +65,22 @@ module ol_framework::vouch_limits {
       } else if (is_root) {
         // exempt from scoring, and epoch limits
         // but others apply
-        assert_safety_ceiling_vouches(grantor_acc);
-        assert_received_limit_vouches(grantor_acc);
+        // assert_received_limit_vouches(grantor_acc);
         assert_revoke_cooldown_period(grantor_acc);
+        assert_safety_ceiling_vouches(grantor_acc);
+
       }
     }
 
     fun assert_all_checks(grantor_acc: address) {
-      assert_safety_ceiling_vouches(grantor_acc);
       assert_max_vouches_by_score(grantor_acc);
-      assert_received_limit_vouches(grantor_acc);
+      // assert_received_limit_vouches(grantor_acc);
       assert_epoch_vouches_limit(grantor_acc);
       // prevents user from revoking many and subsequently adding
       // to bypass the limits
       assert_revoke_cooldown_period(grantor_acc);
+      assert_safety_ceiling_vouches(grantor_acc);
+
     }
 
     fun assert_safety_ceiling_vouches(grantor_acc: address) {
@@ -216,24 +218,24 @@ module ol_framework::vouch_limits {
       let given_count = vector::length(&vouch::get_given_vouches_not_expired(addr));
 
       // check what the score would allow.
-      let score_limit = calculate_score_limit(addr);
+      let vouches_allowed = calculate_score_limit(addr);
       // root users exempt from the score limit
       if (root_of_trust::is_root_at_registry(@diem_framework, addr)) {
-        score_limit = BASE_MAX_VOUCHES;
+        vouches_allowed = BASE_MAX_VOUCHES;
       };
 
-      // check based on how many received
-      // Received limit: non-expired received vouches + 1
-      let true_friends = vouch::true_friends(addr);
-      let received_limit = vector::length(&true_friends) + 1;
+      // // check based on how many received
+      // // Received limit: non-expired received vouches + 1
+      // let true_friends = vouch::true_friends(addr);
+      // let received_limit = vector::length(&true_friends) + 1;
 
 
-      // find the lowest number, most restrictive limit
-      let vouches_allowed = if (score_limit < received_limit) {
-        score_limit
-      } else {
-        received_limit
-      };
+      // // find the lowest number, most restrictive limit
+      // let vouches_allowed = if (score_limit < received_limit) {
+      //   score_limit
+      // } else {
+      //   received_limit
+      // };
 
       vouches_allowed = if (vouches_allowed < BASE_MAX_VOUCHES) {
         vouches_allowed


### PR DESCRIPTION

- [x] vouch limits by receipt were only allowing incrementing by 1 always, deprecated in favor of score
- [x] reauth tx for donor voice was always aborting
- [x] reauth tally needed more data returned for view
- [x] newly initialized community wallets are not flagged for reauth
- [x] patch check for yearly activity failing on testsuite

