### PR TITLE
[testnet] twin initialization patches

### DIFF
--- a/framework/cached-packages/src/libra_framework_sdk_builder.rs
+++ b/framework/cached-packages/src/libra_framework_sdk_builder.rs
@@ -156,7 +156,8 @@ pub enum EntryFunctionCall {
         amount: u64,
     },
 
-    /// Disable the community wallet if the loan is overdue
+    /// Disable the community wallet if the loan is overdue, callable
+    /// by any authorized user account
     CommunityWalletAdvanceMaybeDeauthorize {
         dv_account: AccountAddress,
     },
@@ -1205,7 +1206,8 @@ pub fn coin_transfer(coin_type: TypeTag, to: AccountAddress, amount: u64) -> Tra
     ))
 }
 
-/// Disable the community wallet if the loan is overdue
+/// Disable the community wallet if the loan is overdue, callable
+/// by any authorized user account
 pub fn community_wallet_advance_maybe_deauthorize(
     dv_account: AccountAddress,
 ) -> TransactionPayload {

--- a/framework/libra-framework/sources/block.move
+++ b/framework/libra-framework/sources/block.move
@@ -271,8 +271,7 @@ module diem_framework::block {
     }
 
     #[test(diem_framework = @diem_framework, account = @0x123)]
-    //#[expected_failure(abort_code = 0x50003, location = diem_framework::system_addresses)] //TODO: remove after testing fork
-    #[ignore] //TODO: remove after testing fork
+    #[expected_failure(abort_code = 327680, location = diem_framework::system_addresses)]
     public entry fun test_update_epoch_interval_unauthorized_should_fail(
         diem_framework: signer,
         account: signer,

--- a/framework/libra-framework/sources/block.move
+++ b/framework/libra-framework/sources/block.move
@@ -79,10 +79,10 @@ module diem_framework::block {
     /// Update the epoch interval.
     /// Can only be called as part of the Diem governance proposal process established by the DiemGovernance module.
     public(friend) fun update_epoch_interval_microsecs(
-        _diem_framework: &signer,
+        diem_framework: &signer,
         new_epoch_interval: u64,
     ) acquires BlockResource {
-        //system_addresses::assert_vm(diem_framework); //TODO: remove after testing fork
+        system_addresses::assert_diem_framework(diem_framework); //TODO: remove after testing fork
         assert!(new_epoch_interval > 0, error::invalid_argument(EZERO_EPOCH_INTERVAL));
 
         let block_resource = borrow_global_mut<BlockResource>(@diem_framework);
@@ -271,7 +271,7 @@ module diem_framework::block {
     }
 
     #[test(diem_framework = @diem_framework, account = @0x123)]
-    #[expected_failure(abort_code = 327680, location = diem_framework::system_addresses)]
+    #[expected_failure(abort_code = 327683, location = diem_framework::system_addresses)]
     public entry fun test_update_epoch_interval_unauthorized_should_fail(
         diem_framework: signer,
         account: signer,

--- a/framework/libra-framework/sources/block.move
+++ b/framework/libra-framework/sources/block.move
@@ -14,9 +14,9 @@ module diem_framework::block {
     use diem_framework::system_addresses;
     use diem_framework::timestamp;
     use diem_std::debug::print;
-    use ol_framework::testnet;
 
-    //////// 0L ////////
+    use ol_framework::testnet;
+    use ol_framework::globals;
     use ol_framework::epoch_boundary;
 
     friend diem_framework::genesis;
@@ -74,6 +74,12 @@ module diem_framework::block {
                 update_epoch_interval_events: account::new_event_handle<UpdateEpochIntervalEvent>(diem_framework),
             }
         );
+    }
+
+    /// useful for twin testnet
+    fun set_interval_with_global(diem_framework: &signer) acquires BlockResource {
+      system_addresses::assert_diem_framework(diem_framework);
+      update_epoch_interval_microsecs(diem_framework, globals::get_epoch_microsecs());
     }
 
     /// Update the epoch interval.

--- a/framework/libra-framework/sources/genesis.move
+++ b/framework/libra-framework/sources/genesis.move
@@ -137,6 +137,8 @@ module diem_framework::genesis {
 
         chain_id::initialize(&diem_framework_account, chain_id);
         reconfiguration::initialize(&diem_framework_account);
+
+        // TODO: the epoch interval should be set on Move global.move, not externally.
         block::initialize(&diem_framework_account, epoch_interval_microsecs);
         state_storage::initialize(&diem_framework_account);
         randomness::initialize(&diem_framework_account);

--- a/framework/libra-framework/sources/ol_sources/config/globals.move
+++ b/framework/libra-framework/sources/ol_sources/config/globals.move
@@ -32,7 +32,9 @@ module ol_framework::globals {
 
 
     /// Get the epoch length
-    public fun get_epoch_length(): u64 {
+    // TODO: deduplicate. At genesis it is set externally
+    //  with genesis_builder.rs, vm.rs, and genesis.rs
+    public fun get_epoch_microsecs(): u64 {
        get_constants().epoch_length
     }
 
@@ -106,7 +108,7 @@ module ol_framework::globals {
 
       if (testnet::is_testnet()) {
         return GlobalConstants {
-          epoch_length: 60, // seconds
+          epoch_length: 2 * 60 * 1_000_000, // two minutes
           val_set_at_genesis: 10,
           subsidy_ceiling_gas: 296 * get_coin_scaling_factor(),
           vdf_difficulty_baseline: 100,
@@ -127,7 +129,7 @@ module ol_framework::globals {
         // All numbers like MAINNET except shorter epochs of 30 mins
         // and minimum mining of 1 proof
         return GlobalConstants {
-          epoch_length: 60 * 30, // 30 mins, enough for a hard miner proof.
+          epoch_length: 5 * 60 * 1_000_000, // 5 mins
           val_set_at_genesis: 100, // max expected for BFT limits.
           // See DiemVMConfig for gas constants:
           // Target max gas units per transaction 100000000
@@ -148,7 +150,7 @@ module ol_framework::globals {
         }
       } else {
         return GlobalConstants {
-          epoch_length: 60 * 60 * 24, // approx 24 hours at 1.4 vdf_proofs/sec
+          epoch_length: 24 * 60 * 60 * 1_000_000, // 24 hours
           val_set_at_genesis: 100, // max expected for BFT limits.
           // See DiemVMConfig for gas constants:
           // Target max gas units per transaction 100000000

--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -459,7 +459,6 @@ module diem_framework::epoch_boundary {
 
   fun process_incoming_validators(root: &signer, status: &mut BoundaryStatus, compliant_vals: vector<address>, n_seats: u64) {
     system_addresses::assert_ol(root);
-
     // check amount of fees expected
     let (auction_winners, all_bidders, only_qualified_bidders, entry_fee) = proof_of_fee::end_epoch(root, &compliant_vals, n_seats);
     status.incoming_filled_seats = vector::length(&auction_winners);
@@ -481,6 +480,7 @@ module diem_framework::epoch_boundary {
     status.incoming_fees_success = fee_success;
     // make sure musical chairs doesn't keep incrementing if we are persistently
     // offering more seats than can be filled
+
     let final_set_size = vector::length(&actual_set);
     musical_chairs::set_current_seats(root, final_set_size);
     status.incoming_final_set_size = final_set_size;

--- a/framework/libra-framework/sources/ol_sources/epoch_boundary.move
+++ b/framework/libra-framework/sources/ol_sources/epoch_boundary.move
@@ -301,7 +301,7 @@ module diem_framework::epoch_boundary {
   /// Contains all of 0L's business logic for end of epoch.
   /// This removed business logic from reconfiguration.move
   /// and prevents dependency cycling.
-  // TODO: do we need closing_epoch if there is no depedency cycling with reconfiguration::
+  // TODO: do we need closing_epoch if there is no dependency cycling with reconfiguration::
   public(friend) fun epoch_boundary(root: &signer, closing_epoch: u64, epoch_round: u64)
   acquires BoundaryStatus {
     print(&string::utf8(b"EPOCH BOUNDARY BEGINS"));

--- a/framework/libra-framework/sources/ol_sources/migrations.move
+++ b/framework/libra-framework/sources/ol_sources/migrations.move
@@ -8,9 +8,6 @@ module ol_framework::migrations {
 
   use diem_std::debug::print;
 
-  // migrations
-  // use ol_framework::vouch_migration;
-
   //////// CONST ////////
   const EMIGRATIONS_NOT_INITIALIZED: u64 = 1;
 
@@ -84,6 +81,8 @@ module ol_framework::migrations {
     };
   }
 
+  #[view]
+  /// see which migration ran most recently
   public fun get_last_migration_number(): u64 acquires Migrations {
     if (!exists<Migrations>(@ol_framework)) {
       return 0
@@ -93,6 +92,8 @@ module ol_framework::migrations {
     state.last_migration
   }
 
+  #[view]
+  /// get the state of the migrations
   public fun get_last_migrations_history(): (u64, u64, vector<u8>) acquires Migrations {
     assert!(exists<Migrations>(@ol_framework), error::invalid_state(EMIGRATIONS_NOT_INITIALIZED));
 

--- a/framework/libra-framework/sources/ol_sources/vouch_lib/root_of_trust.move
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/root_of_trust.move
@@ -221,7 +221,7 @@ module ol_framework::root_of_trust {
         }
     }
 
-        #[view]
+    #[view]
     /// Get the genesis root of trust, useful for testing
     /// refers to Nov 14 2021 Genesis Validator set
     /// https://github.com/0LNetworkCommunity/genesis-registration

--- a/framework/libra-framework/sources/stake.move
+++ b/framework/libra-framework/sources/stake.move
@@ -17,8 +17,6 @@ module diem_framework::stake {
     use ol_framework::testnet;
     use ol_framework::address_utils;
 
-
-
     friend diem_framework::block;
     friend diem_framework::genesis;
     friend diem_framework::reconfiguration;
@@ -814,8 +812,10 @@ module diem_framework::stake {
 
         if (seats_offered < minimum_seats) { seats_offered = minimum_seats };
         // let min_f = 3;
+
         let current_vals = get_current_validators();
         // check if this is not test. Failover only when there are no validators proposed
+
         if (testnet::is_testnet()) {
           // ignore if no vals are returning.
           if (vector::length(&proposed) == 0) {
@@ -829,23 +829,27 @@ module diem_framework::stake {
         let enough_qualified = count_proposed > healthy_threshold;
 
         // expand the least amount, otherwise we could halt again
-        // with unprepared validtors.
+        // with unprepared validators.
         let new_target = if (seats_offered > healthy_threshold)
         healthy_threshold else seats_offered;
         // do we have 10 or more performant validators (whether or not they
         // qualified for next epoch)?
 
+
         // Scenario A) Happy Case
         // not near failure
         if (enough_qualified) {
+
           return proposed
         } else if (new_target >= 4) {
+
           // we won't dig out of the hole if we target less than 4
           // Scenario B) Sick Patient
           // always fill seats with proposed/qualified if possible.
           // if not, go to hail mary
           if (count_proposed >= new_target) { // should not be higher, most
           // likely equal
+
             return proposed
           } else {
             // Scenario C) Defibrillator
@@ -856,16 +860,26 @@ module diem_framework::stake {
 
             // fill remaining seats with
             // take the most performant validators from previous epoch.
+
+
             let remainder = new_target - count_proposed;
+
             let ranked = get_sorted_vals_by_net_props();
+
+
+
             let i = 0;
-            while (i < remainder) {
+
+            while
+              ((i < remainder) &&
+              (i < vector::length(&ranked))) {
               let best_val = vector::borrow(&ranked, i);
               if (!vector::contains(&proposed, best_val)) {
                 vector::push_back(&mut proposed, *best_val)
               };
               i = i + 1;
-            }
+            };
+
           }
         };
 
@@ -875,7 +889,8 @@ module diem_framework::stake {
         if (vector::length(&proposed) > 3) {
           return proposed
         };
-        // this is unreachable but as a backstop for dev finge
+        // this is unreachable but as a backstop for dev finge (sic)
+
         current_vals
     }
 

--- a/tools/genesis/src/vm.rs
+++ b/tools/genesis/src/vm.rs
@@ -35,10 +35,12 @@ use libra_types::ol_progress::OLProgress;
 /// NOTE: many of the parameters are ignored in libra_framework
 /// but are kept for api compatibility.
 pub fn libra_genesis_default(chain: NamedChain) -> GenesisConfiguration {
+    // Note: check this against the move definitions in globals.move
+    // TODO: make this config internal to Move, and not set at genesis
     let epoch_duration_secs = match chain {
         NamedChain::MAINNET => 24 * 60 * 60, // one day
         NamedChain::TESTING => 2 * 60,       // for CI suite: two mins
-        _ => 15 * 60, // for all testnets, not using mainnet settings, 15 mins
+        _ => 5 * 60, // for all testnets, not using mainnet settings, 15 mins
     };
     GenesisConfiguration {
         allow_new_validators: true,

--- a/tools/rescue/src/session_tools.rs
+++ b/tools/rescue/src/session_tools.rs
@@ -218,6 +218,21 @@ pub fn change_chain_id(session: &mut SessionExt, chain_id: u8) -> anyhow::Result
     let signer = MoveValue::Signer(AccountAddress::ONE);
     let chain_id = MoveValue::U8(chain_id);
     libra_execute_session_function(session, "0x1::chain_id::set_impl", vec![&signer, &chain_id])?;
+
+    libra_execute_session_function(
+        session,
+        "0x1::block::update_epoch_interval_microsecs",
+        // 5 minutes
+        // TODO: get from globals
+        vec![&signer, &MoveValue::U64(5 * 60 * 1_000_000)],
+    )?;
+
+    // TODO: uncomment this after v8
+    // libra_execute_session_function(
+    //     session,
+    //     "0x1::block::set_interval_with_global",
+    //     vec![&signer],
+    // )?;
     Ok(())
 }
 
@@ -235,6 +250,14 @@ pub fn remove_gov_mode_flag(session: &mut SessionExt) -> anyhow::Result<()> {
     )?;
     Ok(())
 }
+
+// TODO: possibly useful, however it would never run new migrations
+// in a forthcoming upgrade version of framework
+// pub fn migrate_data(session: &mut SessionExt) -> anyhow::Result<()> {
+//     let signer = MoveValue::Signer(AccountAddress::ONE);
+//     libra_execute_session_function(session, "0x1::epoch_boundary::migrate_data", vec![&signer])?;
+//     Ok(())
+// }
 
 /// Unpacks a VM change set.
 pub fn unpack_to_changeset(vmc: VMChangeSet) -> anyhow::Result<ChangeSet> {

--- a/tools/testnet/Makefile
+++ b/tools/testnet/Makefile
@@ -1,122 +1,30 @@
-# NOTE: you'll need to have a db of a fullnode already synced
-# twin tool will make a copy of this
-# THE DB WILL NOT BE WRITTEN TO
+TWIN_JSON = ./twin.json
+FRAMEWORK = ../../framework
+DB_PATH = ~/.libra/db_365
 
-# TMP_DIR = /tmp/.tmpCu3Rxh/
+framework:
+	cd ${FRAMEWORK} && libra move framework release
 
-ifndef DB_DIR
-DB_DIR=$$HOME/.libra/data/db
-endif
+twin:
+	cargo r -p libra -- ops testnet -f ${FRAMEWORK}/releases/head.mrb -r ${DB_PATH} --json-file ${TWIN_JSON} smoke
 
-ifndef UPGRADE_SCRIPT_PATH
-UPGRADE_SCRIPT_PATH = $$HOME/upgrade-six/
-endif
+parse-jq:
+	$(eval APP_CFG=$(shell jq -r '.[0].app_cfg_path' ${TWIN_JSON}))
+	@echo "APP_CFG set to: ${APP_CFG}"
 
-ifndef FRAMEWORK_SOURCE_PATH
-FRAMEWORK_SOURCE_PATH = $$HOME/libra-framework/framework
-endif
+grep-debug:
+	$(eval LOG_DIR=$(shell jq -r '.[0].data_dir' ${TWIN_JSON})/log)
+	@echo "Searching for EPOCH in: ${LOG_DIR}"
+	grep -e "\[debug\]" ${LOG_DIR}
 
-ifndef DIEM_FORGE_NODE_BIN_PATH
-DIEM_FORGE_NODE_BIN_PATH = $$HOME/.cargo/bin/libra
-endif
+####### TRANSACTIONS
 
-PROPOSAL_ID = 6
+send-human: parse-jq
+	cargo r -p libra -- txs -c ${APP_CFG} user human-founder
 
-##### INSTRUCTIONS
+send-epoch: parse-jq
+	cargo r -p libra -- txs -c ${APP_CFG} governance epoch-boundary
 
-# Grab the essentials:
-# sudo apt update
-# sudo apt install -y git build-essential cmake clang llvm libgmp-dev pkg-config libssl-dev lld libpq-dev
-# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# 1. use an up to date libra-cli binary
-# > cargo build --release -p libra --locked
-# > cp target/release/libra ~/.cargo/bin/
-
-# 2. Make sure you have a fullnode that is already syced, you'll need the DB_DIR of it
-# if you are starting fresh use:
-# > libra config fullnode-init
-# > libra node
-# check height while syncing
-# > watch -n 5 'curl -s 127.0.0.1:9101/metrics | grep diem_state_sync_version'
-
-# 2. compile the new libra-framework MOVE code with:
-# > make upgrade-script
-# note the defaults for input: FRAMEWORK_SOURCE_PATH and and output: UPGRADE_SCRIPT_PATH
-
-# 3. start a Twin swarm locally
-# > make start-twin
-# NOTE: the output `temp files found at: /tmp/<......> `
-# A local Twin of mainnet is now running on your machine.
-
-# 4. export that temp dir to your path
-# > export TMP_DIR=/tmp/<......>
-
-# Now your can do transactions as the new random validators
-# 5. check validator set
-# > make view-vals
-
-# 6. try to tigger epoch
-# > make tx-epoch
-# NOTE: this usually should fail unless enough time has passed.
-
-# 7. Send the full upgrade e2e
-# > make upgrade-ceremony
-
-# 8. check the state of the proposal
-# > make view-state
-
-# start twin with three validators
-start-twin:
-	cargo run -p libra-twin-tests -- -d ${DB_DIR} -c 3
-
-
-#########  UPGRADE SCRIPT GENERATION
-upgrade-script: move-build-framework move-build-script
-
-move-build-framework:
-	cd ${FRAMEWORK_SOURCE_PATH} && libra move framework release
-
-move-build-script:
-	libra move framework upgrade --core-modules libra-framework --output-dir ${UPGRADE_SCRIPT_PATH} --framework-local-dir ${FRAMEWORK_SOURCE_PATH}
-
-######## EPOCH TRIGGER
-tx-epoch:
-	libra txs -c ${TMP_DIR}/0/libra-cli-config.yaml governance epoch-boundary
-
-
-######## UPGRADE TRANSACTIONS
-upgrade-ceremony: tx-propose tx-vote tx-resolve
-
-tx-propose:
-	libra txs -c ${TMP_DIR}/0/libra-cli-config.yaml governance propose -d ${UPGRADE_SCRIPT_PATH}/1-libra-framework -m https://tbd.com
-
-tx-vote:
-	libra txs -c ${TMP_DIR}/0/libra-cli-config.yaml governance vote -i ${PROPOSAL_ID}
-	libra txs -c ${TMP_DIR}/1/libra-cli-config.yaml governance vote -i ${PROPOSAL_ID}
-	libra txs -c ${TMP_DIR}/2/libra-cli-config.yaml governance vote -i ${PROPOSAL_ID}
-
-tx-resolve:
-	libra txs -c ${TMP_DIR}/0/libra-cli-config.yaml --tx-profile critical governance resolve -i ${PROPOSAL_ID} -d ${UPGRADE_SCRIPT_PATH}/1-libra-framework
-
-#### VIEW STATE OF UPGRADE PROPOSALS
-view-state:
-	libra query -c ${TMP_DIR}/0/libra-cli-config.yaml view -f 0x1::diem_governance::get_proposal_state -a ${PROPOSAL_ID}
-
-view-resolve:
-	libra query -c ${TMP_DIR}/0/libra-cli-config.yaml view -f 0x1::diem_governance::get_can_resolve -a ${PROPOSAL_ID}
-
-view-vals:
-	libra query -c ${TMP_DIR}/0/libra-cli-config.yaml view -f 0x1::stake::get_current_validators
-
-
-######## OTHER
-debug-keys:
-	cat ${TMP_DIR}/0/private-identity.yaml
-	cat ${TMP_DIR}/1/private-identity.yaml
-	cat ${TMP_DIR}/2/private-identity.yaml
-
-help-tx-bid-shuffle:
-	libra txs -c ${TMP_DIR}/0/libra-cli-config.yaml validator pof -b 0.3 -e 1000
-	libra txs -c ${TMP_DIR}/1/libra-cli-config.yaml validator pof -b 0.4 -e 1000
-	libra txs -c ${TMP_DIR}/2/libra-cli-config.yaml validator pof -b 0.5 -e 1000
+#### QUERIES
+query-roots:  parse-jq
+	libra query -c ${APP_CFG} view -f 0x1::root_of_trust::get_current_roots_at_registry -a 0x1

--- a/tools/testnet/src/cli_main.rs
+++ b/tools/testnet/src/cli_main.rs
@@ -116,7 +116,6 @@ impl TestnetCli {
                     println!("Writing test info to JSON file: {:?}", file_path);
                     fs::write(&file_path, res)
                         .map_err(|e| anyhow::anyhow!("Failed to write to JSON file: {}", e))?;
-                    println!("Successfully wrote test info to {:?}", file_path);
                 }
             }
             Err(e) => {

--- a/tools/testnet/src/cli_swarm.rs
+++ b/tools/testnet/src/cli_swarm.rs
@@ -69,7 +69,6 @@ impl SwarmCliOpts {
             println!("Writing test info to JSON file: {:?}", file_path);
             fs::write(&file_path, serde_json::to_string_pretty(&out)?)
                 .map_err(|e| anyhow::anyhow!("Failed to write to JSON file: {}", e))?;
-            println!("Successfully wrote test info to {:?}", file_path);
         } else {
             // If not writing to file, print the regular output
             println!("{}", serde_json::to_string_pretty(&out)?);


### PR DESCRIPTION

- [x] [move] fix a mismatched length of validators on reconfiguration when the validators set is smaller than mainnet bidders
- [x] at writeset turn off governance mode by default
- [x] at writeset set the epoch interval to 5 minutes (correct for TESTNET chain_id =2)
- [x] fix epoch interval length handling in move

Future improvements
There is duplication, between Rust and Move code for setting epoch intervals. The move code should contain the defaults.
