### PR TITLE
[slow wallet] reset transferred to 0 plus global unlock tracker

### DIFF
--- a/framework/libra-framework/sources/ol_sources/slow_wallet.move
+++ b/framework/libra-framework/sources/ol_sources/slow_wallet.move
@@ -17,8 +17,6 @@ module ol_framework::slow_wallet {
   use ol_framework::sacred_cows;
   use ol_framework::testnet;
 
-
-
   friend diem_framework::genesis;
   friend ol_framework::ol_account;
   friend ol_framework::transaction_fee;
@@ -395,10 +393,9 @@ module ol_framework::slow_wallet {
     /// - total: the total balance of all slow wallet accounts
     /// - transferred: the total amount that has been transferred from all slow wallets
     public fun get_slow_supply(): (u64, u64, u64) acquires SlowWallet, SlowWalletList {
-      let _system_supply = libra_coin::supply();
-
       let list = get_slow_list();
       let len = vector::length<address>(&list);
+
       let total = 0;
       let unlocked = 0;
       let transferred = 0;

--- a/framework/libra-framework/sources/ol_sources/slow_wallet.move
+++ b/framework/libra-framework/sources/ol_sources/slow_wallet.move
@@ -94,6 +94,7 @@ module ol_framework::slow_wallet {
         // for already existing accounts
         let state = borrow_global_mut<SlowWallet>(signer::address_of(sig));
         state.unlocked = 0;
+        state.transferred = 0;
     }
 
     /// Users can change their account to slow, by calling the entry function

--- a/framework/libra-framework/sources/ol_sources/supply.move
+++ b/framework/libra-framework/sources/ol_sources/supply.move
@@ -34,7 +34,7 @@ module ol_framework::supply {
     // So we calculated what has be transferred out of
     // slow wallets, and from community wallets
     let slow_unlocked = slow_wallet::get_lifetime_unlocked_supply();
-    let slow_locked = slow_wallet::get_locked_supply();
+    let slow_locked = total - community_endowments - future_pledges - slow_unlocked;
 
     // TODO: add unlocked coins that CW have from advances
 


### PR DESCRIPTION
- [x] transferred tracker on an account was not resetting on migration
- [x] includes a tracker for global system daily unlocks