### PR TITLE
[community wallet] refactor advance loan for cw

### DIFF
--- a/framework/libra-framework/sources/account.move
+++ b/framework/libra-framework/sources/account.move
@@ -1036,6 +1036,10 @@ module diem_framework::account {
       WithdrawCapability { addr: signer::address_of(owner) }
     }
 
+    public fun destroy_withdraw_capability(cap: WithdrawCapability)  {
+        let WithdrawCapability { addr: _ } = cap;
+    }
+
     public fun get_withdraw_cap_address(cap: &WithdrawCapability): address {
         cap.addr
     }

--- a/framework/libra-framework/sources/ol_sources/community_wallet_advance.move
+++ b/framework/libra-framework/sources/ol_sources/community_wallet_advance.move
@@ -21,7 +21,7 @@ module ol_framework::community_wallet_advance {
   use std::error;
   use std::signer;
   use std::timestamp;
-  use diem_framework::account::{Self, GUIDCapability};
+  use diem_framework::account::{Self, WithdrawCapability};
   use diem_framework::coin::{Coin};
   use ol_framework::ol_account;
   use ol_framework::libra_coin::{Self, LibraCoin};
@@ -109,11 +109,17 @@ module ol_framework::community_wallet_advance {
   }
   /// Only can be called on epoch boundary as part of the donor_voice_txs.move authorization flow.
   /// Will withdraw funds and track the logger
-  public(friend) fun transfer_credit(framework_sig: &signer, guid_cap: &GUIDCapability, recipient: address, amount: u64): u64 acquires Advances {
-    let dv_account = account::get_guid_capability_address(guid_cap);
+  public(friend) fun transfer_credit(withdraw_cap: &WithdrawCapability, recipient: address, amount: u64): u64 acquires Advances {
+    let dv_account = account::get_withdraw_cap_address(withdraw_cap);
+
     can_withdraw_amount(dv_account, amount);
     log_withdrawal(dv_account, amount);
-    ol_account::vm_transfer(framework_sig, dv_account, recipient, amount);
+
+    ol_account::transfer_with_capability(
+      withdraw_cap,
+      recipient,
+      amount,
+    );
     // TODO: check if there is any possibility of partial amount sent
     amount
   }

--- a/framework/libra-framework/sources/ol_sources/tests/community_wallet.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/community_wallet.test.move
@@ -142,7 +142,7 @@
 
         // VERIFY PAYMENTS OPERATE AS EXPECTED
         // bob propose payment
-        let _uid = donor_voice_txs::test_propose_payment(bob, alice_comm_wallet_addr, carols_addr, 100, b"thanks carol", false);
+        let _uid = donor_voice_txs::test_propose_payment(bob, alice_comm_wallet_addr, carols_addr, 100, b"thanks carol");
 
     }
 
@@ -177,7 +177,7 @@
 
         // VERIFY PAYMENTS OPERATE AS EXPECTED
         // bob propose payment
-        let uid = donor_voice_txs::test_propose_payment(bob, alice_comm_wallet_addr, carols_addr, 100, b"thanks carol", false);
+        let uid = donor_voice_txs::test_propose_payment(bob, alice_comm_wallet_addr, carols_addr, 100, b"thanks carol");
         let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(alice_comm_wallet_addr, &uid);
         assert!(found, 7357004);
         assert!(idx == 0, 7357005);
@@ -188,7 +188,7 @@
         assert!(!donor_voice_txs::is_scheduled(alice_comm_wallet_addr, &uid), 7357008);
 
         // dave votes the payment and it is approved.
-        let uid = donor_voice_txs::test_propose_payment(dave, alice_comm_wallet_addr, @0x1000c, 100, b"thanks carol", false);
+        let uid = donor_voice_txs::test_propose_payment(dave, alice_comm_wallet_addr, @0x1000c, 100, b"thanks carol");
         let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(alice_comm_wallet_addr, &uid);
         assert!(found, 7357004);
         assert!(idx == 0, 7357005);
@@ -397,10 +397,12 @@
       let d = community_wallet_advance::is_delinquent(comm_addr);
       assert!(!d, 7357003);
 
-      let cap = account::create_guid_capability(community);
+      // let cap = account::create_guid_capability(community);
+
+      let w_cap = account::extract_withdraw_capability(community);
 
       // community wallet transfers an amount to alice
-      community_wallet_advance::transfer_credit(root, &cap, @0x1000a, 10000);
+      community_wallet_advance::transfer_credit(&w_cap, @0x1000a, 10000);
 
       let (_, comm_balance) = ol_account::balance(comm_addr);
       let (_, alice_balance) = ol_account::balance(@0x1000a);
@@ -421,8 +423,6 @@
       assert!(bal != 0, 7357008);
       assert!(bal > bal_before, 7357009);
 
-      // restore
-      // std::option::fill(&mut cap_opt, cap);
-      // multi_action::maybe_restore_withdraw_cap(cap_opt);
+      account::destroy_withdraw_capability(w_cap);
     }
 }

--- a/framework/libra-framework/sources/ol_sources/tests/donor_voice.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/donor_voice.test.move
@@ -92,7 +92,7 @@ module ol_framework::test_donor_voice {
       //need to be caged to finalize donor directed workflow and release control of the account
       multi_action::finalize_and_cage(&resource_sig, vector::length(&vals));
 
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -124,7 +124,7 @@ module ol_framework::test_donor_voice {
       //need to cage to finalize donor directed workflow and release control of the account
       multi_action::finalize_and_cage(&resource_sig, 2);
 
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -134,7 +134,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
 
-      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -191,7 +191,7 @@ module ol_framework::test_donor_voice {
 
       // Bob proposes a tx that will come from the donor directed account.
       // It is not yet scheduled because it doesnt have the MultiAuth quorum. Still waiting for Alice or Carol to approve.
-      let uid_of_transfer = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid_of_transfer = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (_found, _idx, _status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid_of_transfer);
       assert!(!completed, 7357004);
 
@@ -203,7 +203,7 @@ module ol_framework::test_donor_voice {
 
       // Now Carol, along with Bob, as admins have proposed the payment.
       // Now the payment should be scheduled
-      let uid_of_transfer = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid_of_transfer = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob");
       assert!(donor_voice_txs::is_scheduled(donor_voice_address, &uid_of_transfer), 7357006); // is scheduled
 
       // Eve tries again after it has been scheduled
@@ -259,7 +259,7 @@ module ol_framework::test_donor_voice {
       //need to cage to finalize donor directed workflow and release control of the account
       multi_action::finalize_and_cage(&resource_sig, 2);
 
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000c, 100, b"thanks carol", false);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000c, 100, b"thanks carol");
 
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
@@ -270,7 +270,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
 
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000c, 100, b"thanks carol", false);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000c, 100, b"thanks carol");
 
       // confirm it is scheduled
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
@@ -310,7 +310,7 @@ module ol_framework::test_donor_voice {
       multi_action::finalize_and_cage(&resource_sig, 2);
 
 
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -320,7 +320,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
 
-      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -387,7 +387,7 @@ module ol_framework::test_donor_voice {
 
       donor_voice_reauth::test_set_authorized(root, donor_voice_address);
 
-      let uid = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), 100, b"thanks marlon", false);
+      let uid = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), 100, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -397,7 +397,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
 
-      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), 100, b"thanks marlon", false);
+      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), 100, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -463,7 +463,7 @@ module ol_framework::test_donor_voice {
 
       slow_wallet::user_set_slow(marlon_rando);
 
-      let first_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon", false);
+      let first_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &first_uid_bob);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -473,7 +473,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &first_uid_bob), 7357008);
 
-      let first_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon", false);
+      let first_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &first_uid_carol);
       assert!(found, 7357009);
       assert!(idx == 0, 73570010);
@@ -487,7 +487,7 @@ module ol_framework::test_donor_voice {
       let list = donor_voice_txs::find_by_deadline(donor_voice_address, 3);
       assert!(vector::contains(&list, &first_uid_bob), 73570014);
 
-      let second_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!", false);
+      let second_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &second_uid_bob);
       assert!(found, 73570015);
       assert!(idx == 0, 73570016); // since the above payment was approved, now
@@ -498,7 +498,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &second_uid_bob), 73570019);
 
-      let second_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!", false);
+      let second_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!");
       let (found, idx, status_enum, completed) =
       donor_voice_txs::get_multisig_proposal_state(donor_voice_address,
       &second_uid_carol);
@@ -594,7 +594,7 @@ module ol_framework::test_donor_voice {
 
       slow_wallet::user_set_slow(marlon_rando);
 
-      let uid = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon", false);
+      let uid = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357004);
       assert!(idx == 0, 7357005);
@@ -604,7 +604,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357008);
 
-      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon", false);
+      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_one, b"thanks marlon");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357009);
       assert!(idx == 0, 73570010); // it's index 0 of approved payments
@@ -622,7 +622,7 @@ module ol_framework::test_donor_voice {
       // one epoch goes by and then new payment to marlon
       mock::trigger_epoch(root); // into epoch 1
 
-      let second_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!", false);
+      let second_uid_bob = donor_voice_txs::propose_payment(bob, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &second_uid_bob);
       assert!(found, 73570015);
       assert!(idx == 0, 73570016); // now pending is empty, should be first
@@ -632,7 +632,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &second_uid_bob), 73570019);
 
-      let second_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!", false);
+      let second_uid_carol = donor_voice_txs::test_propose_payment(carol, donor_voice_address, signer::address_of(marlon_rando), marlon_pay_two, b"thanks again!!!");
       let (found, idx, status_enum, completed) =
       donor_voice_txs::get_multisig_proposal_state(donor_voice_address,
       &second_uid_carol);
@@ -912,7 +912,7 @@ module ol_framework::test_donor_voice {
       let gov_mode_id = ol_features_constants::get_governance_mode();
       features::change_feature_flags(root, vector::singleton(gov_mode_id), vector::empty());
 
-      let _uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", false);
+      let _uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
     }
 
     #[test(root = @ol_framework, alice = @0x1000a, bob = @0x1000b, carol = @0x1000c, dave = @0x1000d)]
@@ -939,9 +939,7 @@ module ol_framework::test_donor_voice {
 
       let (_bal, bob_bal_before) = ol_account::balance(@0x1000b);
 
-      let advance_is_true = true; // this is the test, so you don't miss it
-
-      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob", advance_is_true);
+      let uid = donor_voice_txs::test_propose_payment(bob, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357001);
       assert!(idx == 0, 7357002);
@@ -951,7 +949,7 @@ module ol_framework::test_donor_voice {
       // it is not yet scheduled, it's still only a proposal by an admin
       assert!(!donor_voice_txs::is_scheduled(donor_voice_address, &uid), 7357005);
 
-      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob", advance_is_true);
+      let uid = donor_voice_txs::test_propose_payment(carol, donor_voice_address, @0x1000b, 100, b"thanks bob");
       let (found, idx, status_enum, completed) = donor_voice_txs::get_multisig_proposal_state(donor_voice_address, &uid);
       assert!(found, 7357006);
       assert!(idx == 0, 7357007);

--- a/tools/testnet/Makefile
+++ b/tools/testnet/Makefile
@@ -1,16 +1,30 @@
-TWIN_JSON = ./twin.json
-FRAMEWORK = ../../framework
-DB_PATH = ~/.libra/db_365
+TWIN_JSON := ./twin.json
+FRAMEWORK := ../../framework
+DB_PATH := ~/.libra/db_370
 
 framework:
 	cd ${FRAMEWORK} && libra move framework release
 
 twin:
-	cargo r -p libra -- ops testnet -f ${FRAMEWORK}/releases/head.mrb -r ${DB_PATH} --json-file ${TWIN_JSON} smoke
+	libra ops testnet -f ${FRAMEWORK}/releases/head.mrb -r ${DB_PATH} --json-file ${TWIN_JSON} smoke
 
 parse-jq:
 	$(eval APP_CFG=$(shell jq -r '.[0].app_cfg_path' ${TWIN_JSON}))
 	@echo "APP_CFG set to: ${APP_CFG}"
+
+# Helper function to set API endpoint environment variables for a specific node
+set-api-endpoint:
+	$(eval NODE_INDEX ?= 0)
+	$(eval API_HOST=$(shell jq -r '.[${NODE_INDEX}].api_endpoint.host' ${TWIN_JSON}))
+	$(eval API_PORT=$(shell jq -r '.[${NODE_INDEX}].api_endpoint.port' ${TWIN_JSON}))
+	$(eval export LIBRA_API_HOST=${API_HOST})
+	$(eval export LIBRA_API_PORT=${API_PORT})
+	@echo "API endpoint set to: ${API_HOST}:${API_PORT} (for node ${NODE_INDEX})"
+	@echo "Environment variables LIBRA_API_HOST and LIBRA_API_PORT are now set."
+
+# Helper to set API endpoint and show the full URL
+print-api-url: set-api-endpoint
+	@echo "Full API URL: http://${LIBRA_API_HOST}:${LIBRA_API_PORT}"
 
 grep-debug:
 	$(eval LOG_DIR=$(shell jq -r '.[0].data_dir' ${TWIN_JSON})/log)
@@ -20,11 +34,53 @@ grep-debug:
 ####### TRANSACTIONS
 
 send-human: parse-jq
-	cargo r -p libra -- txs -c ${APP_CFG} user human-founder
+	libra txs -c ${APP_CFG} user human-founder
 
 send-epoch: parse-jq
-	cargo r -p libra -- txs -c ${APP_CFG} governance epoch-boundary
+	libra txs -c ${APP_CFG} governance epoch-boundary
 
 #### QUERIES
+
+balance: parse-jq
+	libra query -c ${APP_CFG} balance ${ADDR}
+
+supply: parse-jq
+	libra query -c ${APP_CFG} view -f 0x1::supply::get_stats
+	libra query -c ${APP_CFG} view -f 0x1::slow_wallet::get_slow_supply
+
+# New target that uses the API endpoint from twin.json
+resources: set-api-endpoint
+	curl http://${LIBRA_API_HOST}:${LIBRA_API_PORT}/v1/accounts/${ADDR}/resources > ${ADDR}-resources.json
+
+vouch-score: parse-jq
+	libra query -c ${APP_CFG} view -f 0x1::page_rank_lazy::get_cached_score -a ${ADDR}
+
+cw-status: parse-jq
+	libra query -c ${APP_CFG} view -f 0x1::donor_voice_reauth::is_authorized -a ${CW}
+	libra query -c ${APP_CFG} resource -r 0x1::donor_voice_reauth::DonorAuthorized ${CW}
+	libra query -c ${APP_CFG} view -f 0x1::donor_voice_governance::is_reauth_proposed -a ${CW}
+	libra query -c ${APP_CFG} view -f 0x1::donor_voice_governance::get_reauth_tally -a ${CW}
+
+cw-auth-vote: parse-jq
+	libra txs generate-transaction -f 0x1::donor_voice_txs::vote_reauth_tx -a ${CW}
+
+	# libra txs community reauthorize --community-wallet ${CW}
+
 query-roots:  parse-jq
 	libra query -c ${APP_CFG} view -f 0x1::root_of_trust::get_current_roots_at_registry -a 0x1
+
+
+##### upgrades
+upgrade-payload:
+	libra move framework upgrade -o $$HOME/libra-upgrade  --framework-local-dir ${FRAMEWORK} --core-modules libra-framework --danger-force-upgrade
+
+upgrade-propose: parse-jq
+	libra txs -c ${APP_CFG} governance propose --proposal-script-dir $$HOME/libra-upgrade/1-libra-framework --metadata-url http://allyourbase.com
+
+upgrade-vote: parse-jq
+	libra txs -c ${APP_CFG} governance vote --proposal-id ${PROPOSAL_ID}
+	# get next validator
+	$(eval APP_CFG=$(shell jq -r '.[1].app_cfg_path' ${TWIN_JSON}))
+	libra txs -c ${APP_CFG} user human-founder
+	libra txs -c ${APP_CFG} governance vote --proposal-id ${PROPOSAL_ID}
+	libra txs -c ${APP_CFG} --tx-profile critical governance resolve --proposal-id ${PROPOSAL_ID} --proposal-script-dir $$HOME/libra-upgrade/1-libra-framework

--- a/tools/txs/src/txs_cli_community.rs
+++ b/tools/txs/src/txs_cli_community.rs
@@ -214,13 +214,21 @@ pub struct ProposeTx {
 
 impl ProposeTx {
     pub async fn run(&self, sender: &mut Sender) -> anyhow::Result<()> {
-        let payload = libra_stdlib::donor_voice_txs_propose_payment_tx(
-            self.community_wallet,
-            self.recipient,
-            gas_coin::cast_decimal_to_coin(self.amount as f64),
-            self.description.clone().into_bytes(),
-            self.advance,
-        );
+        let payload = if self.advance {
+            libra_stdlib::donor_voice_txs_propose_advance_tx(
+                self.community_wallet,
+                self.recipient,
+                gas_coin::cast_decimal_to_coin(self.amount as f64),
+                self.description.clone().into_bytes(),
+            )
+        } else {
+            libra_stdlib::donor_voice_txs_propose_payment_tx(
+                self.community_wallet,
+                self.recipient,
+                gas_coin::cast_decimal_to_coin(self.amount as f64),
+                self.description.clone().into_bytes(),
+            )
+        };
         sender.sign_submit_wait(payload).await?;
         Ok(())
     }
@@ -450,7 +458,6 @@ async fn propose_single(
         instruction.parsed.unwrap(),
         gas_coin::cast_decimal_to_coin(instruction.amount as f64),
         instruction.description.clone().into_bytes(),
-        instruction.is_advance,
     );
     sender.sign_submit_wait(payload).await?;
     Ok(())


### PR DESCRIPTION
Migrating from v7 to v8 we had initially introduced a new field to Payment type in donor_voice_txs. Because of the deep nesting of this type present in the v7 mainnet, migrating it is not straightforward. So there had to be a new workflow.

This simplified workflow, requires the signers of the multisig to approve the transaction.