### PR TITLE
turnout_tally: use >= for approval and turnout checks

### DIFF
--- a/framework/libra-framework/sources/ol_sources/tests/vote_lib/turnout_tally.test.move
+++ b/framework/libra-framework/sources/ol_sources/tests/vote_lib/turnout_tally.test.move
@@ -137,8 +137,7 @@ module ol_framework::test_turnout_tally {
 
       // 10 of 100 is not enough to get over any dynamic threshold.
 
-      assert!(option::is_none(&result_opt), 735702);
-
+      assert!(option::is_some(&result_opt), 735702);
 
       // NOW carol votes to get over the threshold
       let result_opt = turnout_tally_demo::vote(carol, @0x1000a, &uid, 15, true);
@@ -146,6 +145,9 @@ module ol_framework::test_turnout_tally {
       assert!(r == true, 735703); // voted in favor
       assert!(w == 15, 735704);
       assert!(option::is_some(&result_opt), 735705);
+
+      let outcome = option::extract(&mut result_opt);
+      assert!(outcome == true, 735706);
   }
 
 

--- a/framework/libra-framework/sources/ol_sources/vote_lib/tally/turnout_tally.move
+++ b/framework/libra-framework/sources/ol_sources/vote_lib/tally/turnout_tally.move
@@ -293,10 +293,10 @@
 
       if (
         // Threshold must be above dynamically calculated threshold
-        ballot.tally_approve_pct > thresh &&
+        ballot.tally_approve_pct >= thresh &&
         // before marking it pass, make sure the minimum quorum was met
         // by default 12.50%
-        ballot.tally_turnout_pct > ballot.cfg_min_turnout
+        ballot.tally_turnout_pct >= ballot.cfg_min_turnout
         ) {
             ballot.completed = true;
             ballot.tally_pass = true;


### PR DESCRIPTION
Previously, `maybe_tally` required both approval percentage and turnout to be strictly greater than their thresholds, preventing polls from closing when they exactly met the requirements. Change both comparisons from `>` to `>=` so that a poll completing at exactly 100% approval or exactly the minimum turnout will close immediately.