### PR TITLE
[fullnode] public fullnode should apply transactions since genesis

### DIFF
--- a/tools/config/src/make_yaml_public_fullnode.rs
+++ b/tools/config/src/make_yaml_public_fullnode.rs
@@ -104,7 +104,7 @@ execution:
 
 state_sync:
      state_sync_driver:
-        bootstrapping_mode: DownloadLatestStates
+        bootstrapping_mode: ExecuteOrApplyFromGenesis
         continuous_syncing_mode: ApplyTransactionOutputs
 
 full_node_networks:


### PR DESCRIPTION
By default new fullnodes should start sync from beginning of current era.