### PR TITLE
[ci] add version and OS matrix to build checks, patch apple silicon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -40,9 +40,3 @@ rustflags = [
   "-C",
   "link-arg=/STACK:8000000", # Set stack to 8 MB
 ]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C",
-  "link-arg=-L/opt/homebrew/opt/gmp",
-]

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -2,7 +2,7 @@
 name: rust-versions
 on:
   push:
-    branches: ["*"] # glob pattern to allow slash /
+    branches: ["**"] # glob pattern to allow slash /
   schedule:
     - cron: "30 00 * * *"
 
@@ -10,7 +10,8 @@ jobs:
   builds:
     strategy:
       matrix:
-        channel: ["stable", "beta"]
+        # lowest supported version, plus stable and beta
+        channel: ["1.78.0", "stable", "beta"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # lowest supported version, plus stable and beta
-        channel: ["1.78.0", "stable", "beta"]
+        channel: ["1.80.1", "stable", "beta"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-versions.yaml
+++ b/.github/workflows/rust-versions.yaml
@@ -2,7 +2,7 @@
 name: rust-versions
 on:
   push:
-    branches: ["ci-bins*"] # glob pattern to allow slash /
+    branches: ["*"] # glob pattern to allow slash /
   schedule:
     - cron: "30 00 * * *"
 
@@ -10,7 +10,8 @@ jobs:
   builds:
     strategy:
       matrix:
-        channel: ["stable", "beta", "nightly"]
+        channel: ["stable", "beta"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Adds nightly checks for lowest rust version (currently 1.80.1), plus "stable" and "beta" toolchains. For each of those toolchains check latest (github runners) for ubuntu, mac, windows.

Note: also patches the .cargo/config.toml which had a deprecated build config for linking GMP (which is no longer needed). This was causing the apple silicon builds to ignore the build configs otherwise found in the file.