### PR TITLE
[donor-voice] initialization of donor-voice fixes

### DIFF
--- a/framework/libra-framework/sources/ol_sources/community_wallet_init.move
+++ b/framework/libra-framework/sources/ol_sources/community_wallet_init.move
@@ -14,8 +14,6 @@ module ol_framework::community_wallet_init {
     use ol_framework::match_index;
     use ol_framework::community_wallet;
     use ol_framework::community_wallet_advance;
-    use ol_framework::reauthorization;
-
 
     #[test_only]
     friend ol_framework::test_community_wallet;
@@ -73,7 +71,6 @@ module ol_framework::community_wallet_init {
       check_threshold: u64,
     ) {
       let signer_addr = signer::address_of(sig);
-      reauthorization::assert_v8_authorized(signer_addr);
 
       check_proposed_auths(initial_authorities, check_threshold);
 

--- a/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
@@ -172,16 +172,19 @@ module ol_framework::donor_voice_txs {
       // commit note: moving this to the end, because it may check data
       // structures that are not yet initialized.
 
-      // check if the account has a meaningful balance
-      // donor voice accounts build slowly through decentralized
-      // donations, and large initialization removes transaction
-      // metadata for donor governance
-      let (_, balance) = ol_account::balance(addr);
-      assert!(balance < MAXIMUM_STARTING_BALANCE, error::invalid_argument(ECANT_INIT_WITH_HIGH_BALANCE));
+      // If account is a pre-v8 CW the balance check will fail
+      if (!donor_voice::is_donor_voice(addr)) {
+        // check users are not bypassing the human verification
+        // for level 8
+        reauthorization::assert_v8_authorized(addr);
 
-      // check users are not bypassing the human verification
-      // for level 8
-      reauthorization::assert_v8_authorized(addr);
+        // check if the account has a meaningful balance
+        // donor voice accounts build slowly through decentralized
+        // donations, and large initialization removes transaction
+        // metadata for donor governance
+        let (_, balance) = ol_account::balance(addr);
+        assert!(balance < MAXIMUM_STARTING_BALANCE, error::invalid_argument(ECANT_INIT_WITH_HIGH_BALANCE));
+      };
 
     }
 

--- a/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
+++ b/framework/libra-framework/sources/ol_sources/donor_voice_txs.move
@@ -156,19 +156,7 @@ module ol_framework::donor_voice_txs {
 
     public(friend) fun make_donor_voice(sponsor: &signer)  {
       assert!(!ol_features_constants::is_governance_mode_enabled(), error::invalid_state(EGOVERNANCE_MODE));
-
-      // check users are not bypassing the human verification
-      // for level 8
       let addr = signer::address_of(sponsor);
-      reauthorization::assert_v8_authorized(addr);
-
-      // check if the account has a meaningful balance
-      // donor voice accounts build slowly through decentralized
-      // donations, and large initialization removes transaction
-      // metadata for donor governance
-      let (_, balance) = ol_account::balance(addr);
-      assert!(balance < MAXIMUM_STARTING_BALANCE, error::invalid_argument(ECANT_INIT_WITH_HIGH_BALANCE));
-
 
       // will not create if already exists (for migration)
       cumulative_deposits::init_cumulative_deposits(sponsor);
@@ -179,6 +167,22 @@ module ol_framework::donor_voice_txs {
       structs_init(sponsor, liquidate_to_match_index);
       make_multi_action(sponsor);
       donor_voice::add(sponsor);
+
+
+      // commit note: moving this to the end, because it may check data
+      // structures that are not yet initialized.
+
+      // check if the account has a meaningful balance
+      // donor voice accounts build slowly through decentralized
+      // donations, and large initialization removes transaction
+      // metadata for donor governance
+      let (_, balance) = ol_account::balance(addr);
+      assert!(balance < MAXIMUM_STARTING_BALANCE, error::invalid_argument(ECANT_INIT_WITH_HIGH_BALANCE));
+
+      // check users are not bypassing the human verification
+      // for level 8
+      reauthorization::assert_v8_authorized(addr);
+
     }
 
     fun structs_init(sig: &signer, liquidate_to_match_index: bool) {
@@ -186,25 +190,32 @@ module ol_framework::donor_voice_txs {
 
       // exit gracefully in migration cases
       // if Freeze exists everything else is likely created
-      if (exists<Freeze>(signer::address_of(sig))) return;
+      if (!exists<Freeze>(signer::address_of(sig))) {
+          move_to<Freeze>(
+          sig,
+          Freeze {
+            is_frozen: false,
+            consecutive_rejections: 0,
+            unfreeze_votes: vector::empty<address>(),
+            liquidate_to_match_index,
+          }
+        );
+      };
 
-      move_to<Freeze>(
-        sig,
-        Freeze {
-          is_frozen: false,
-          consecutive_rejections: 0,
-          unfreeze_votes: vector::empty<address>(),
-          liquidate_to_match_index,
-        }
-      );
 
-      let guid_capability = account::create_guid_capability(sig);
-      move_to(sig, TxSchedule {
+      if (!exists<TxSchedule>(signer::address_of(sig))) {
+        // if the TxSchedule does not exist, we create it
+        // this is the first time we are initializing the account
+        // so we create a GUID capability for the multisig
+        // and then we can use it to schedule payments.
+        let guid_capability = account::create_guid_capability(sig);
+        move_to(sig, TxSchedule {
           scheduled: vector::empty(),
           veto: vector::empty(),
           paid: vector::empty(),
           guid_capability,
         });
+      };
 
       // Commit note: this should now failover gracefully
       donor_voice_governance::maybe_init_dv_governance(sig);

--- a/framework/libra-framework/sources/ol_sources/multi_action.move
+++ b/framework/libra-framework/sources/ol_sources/multi_action.move
@@ -50,6 +50,7 @@ module ol_framework::multi_action {
     #[test_only]
     friend ol_framework::test_community_wallet;
 
+    /// Donor voice governance not initialized
     const EGOV_NOT_INITIALIZED: u64 = 1;
     /// The owner of this account can't be an authority, since it will subsequently be bricked. The signer of this account is no longer useful. The account is now controlled by the Governance logic.
     const ESIGNER_CANT_BE_AUTHORITY: u64 = 2;

--- a/tools/txs/src/txs_cli_community.rs
+++ b/tools/txs/src/txs_cli_community.rs
@@ -41,11 +41,11 @@ impl CommunityTxs {
             CommunityTxs::GovOffer(tx) => tx
                 .run(sender)
                 .await
-                .map(|_| "community wallet offer proposed"),
+                .map(|_| "community wallet admin role offered"),
             CommunityTxs::GovClaim(tx) => tx
                 .run(sender)
                 .await
-                .map(|_| "community wallet offer claimed"),
+                .map(|_| "community wallet admin role claimed"),
             CommunityTxs::GovCage(tx) => tx.run(sender).await.map(|_| "community wallet finalized"),
             CommunityTxs::GovAdmin(tx) => tx
                 .run(sender)


### PR DESCRIPTION
A number of fixes related to community wallets re-joining.
Accounts were unable to process because some checks being done assumed some amount of initialization (assert_authorize).
- [x] remove reauthorization checks upon initialization
- [x] only checks reauthorization if accounts were not previously community wallets
- [x] atomic initialization of governance structs to allow graceful migration