### PR TITLE
[donor-voice] patch cw migration 

### DIFF
--- a/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
+++ b/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
@@ -1,11 +1,18 @@
 module ol_framework::filo_migration {
   use ol_framework::activity;
+  use ol_framework::donor_voice;
   use ol_framework::founder;
   use ol_framework::page_rank_lazy;
   use ol_framework::slow_wallet;
+
   use ol_framework::vouch;
+  use std::signer;
+  use std::error;
 
   friend diem_framework::transaction_validation;
+
+  /// Cannot be used by donor voice accounts
+  const EDONOR_VOICE: u64 = 1;
 
   // Welcome to Level 8
 
@@ -14,6 +21,9 @@ module ol_framework::filo_migration {
   // For a dream that's worth the fight, worth the chase
   // It's a journey, it's a race.
   public entry fun maybe_migrate(user_sig: &signer) {
+    // community wallets should not do this migration
+    assert!(!donor_voice::is_donor_voice(signer::address_of(user_sig)), error::invalid_argument(EDONOR_VOICE));
+
     // Rising up, back on the street
     // Did my time, took my chances
     // Went the distance, now I'm back on my feet

--- a/framework/libra-framework/sources/ol_sources/slow_wallet.move
+++ b/framework/libra-framework/sources/ol_sources/slow_wallet.move
@@ -12,6 +12,7 @@ module ol_framework::slow_wallet {
   use std::vector;
   use diem_framework::account;
   use diem_framework::system_addresses;
+  use ol_framework::community_wallet;
   use ol_framework::libra_coin;
   use ol_framework::reauthorization;
   use ol_framework::sacred_cows;
@@ -305,10 +306,17 @@ module ol_framework::slow_wallet {
         return 0
       };
 
-      if (exists<SlowWallet>(addr)) {
+      if (
+        exists<SlowWallet>(addr) &&
+        // patches bug in v8 where CW may have initialized as user account
+        !community_wallet::is_init(addr)
+      ) {
         let s = borrow_global<SlowWallet>(addr);
         return s.unlocked
       };
+
+      // NOTE: we would use community_wallet_advance::total_credit_available
+      // for community wallets but it causes a dependency loop
 
       // this is a normal account, so return the normal balance
 


### PR DESCRIPTION
We've found an edge case with community wallets making unlocked transactions. The FTW Endowment at some point sent a "re-join" transaction that should only be sent by user accounts. That means it has a mixed up state. Effectively when the balance is checked on the account it shows 0, because there is a SlowWallet data structure which should not be there. Given the incorrect state of zero balance, all unlocked transfers will abort.

Anyhow, This patch prevents the user "re-join" tx from being sent. Also includes a better check on balances for this edge case. 

NOTE: a complete solution would require actually sanitizing the CW that has mixed state, but that's beyond the scope of this patch.