### PR TITLE
[bug] patch duplicate migrate bug

### DIFF
--- a/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
+++ b/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
@@ -5,12 +5,13 @@ module ol_framework::filo_migration {
   use ol_framework::page_rank_lazy;
   use ol_framework::reauthorization;
   use ol_framework::slow_wallet;
-
   use ol_framework::vouch;
   use std::signer;
   use std::error;
 
   friend diem_framework::transaction_validation;
+  #[test_only]
+  friend ol_framework::mock;
 
   /// Error codes
   /// Cannot be used by donor voice accounts
@@ -32,7 +33,11 @@ module ol_framework::filo_migration {
     // don't allow a v8-migrated account to accidentally migrate again
     assert!(!reauthorization::is_v8_authorized(addr), error::invalid_argument(EALREADY_AUTHORIZED));
 
+    migration_impl(user_sig);
+  }
 
+  // FILO FTW
+  fun migration_impl(user_sig: &signer) {
     // Rising up, back on the street
     // Did my time, took my chances
     // Went the distance, now I'm back on my feet
@@ -78,7 +83,14 @@ module ol_framework::filo_migration {
     // It'll be better than before
     // Yesterday's gone, yesterday's gone
     slow_wallet::filo_migration_reset(user_sig);
-
   }
-  // FILO FTW
+
+
+  #[test_only]
+  public(friend) fun test_unchecked_migration(user_sig: &signer) {
+    // This is a test-only function to allow migration without checks.
+    // It should not be used in production code.
+    migration_impl(user_sig);
+  }
+
 }

--- a/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
+++ b/framework/libra-framework/sources/ol_sources/migrations/filo_migration.move
@@ -3,6 +3,7 @@ module ol_framework::filo_migration {
   use ol_framework::donor_voice;
   use ol_framework::founder;
   use ol_framework::page_rank_lazy;
+  use ol_framework::reauthorization;
   use ol_framework::slow_wallet;
 
   use ol_framework::vouch;
@@ -11,8 +12,11 @@ module ol_framework::filo_migration {
 
   friend diem_framework::transaction_validation;
 
+  /// Error codes
   /// Cannot be used by donor voice accounts
   const EDONOR_VOICE: u64 = 1;
+  /// Cannot be used by accounts that have already been authorized for v8
+  const EALREADY_AUTHORIZED: u64 = 2;
 
   // Welcome to Level 8
 
@@ -22,7 +26,12 @@ module ol_framework::filo_migration {
   // It's a journey, it's a race.
   public entry fun maybe_migrate(user_sig: &signer) {
     // community wallets should not do this migration
-    assert!(!donor_voice::is_donor_voice(signer::address_of(user_sig)), error::invalid_argument(EDONOR_VOICE));
+    let addr = signer::address_of(user_sig);
+    assert!(!donor_voice::is_donor_voice(addr), error::invalid_argument(EDONOR_VOICE));
+
+    // don't allow a v8-migrated account to accidentally migrate again
+    assert!(!reauthorization::is_v8_authorized(addr), error::invalid_argument(EALREADY_AUTHORIZED));
+
 
     // Rising up, back on the street
     // Did my time, took my chances
@@ -37,18 +46,6 @@ module ol_framework::filo_migration {
     // I laid the ground for the things to be
     // I'm the spark, I'm the first, I'm the one who created the fire.
     founder::migrate(user_sig);
-
-
-    // All I want is to see you smile
-    // If it takes just a little while
-    // I know you don't believe that it's true
-    // I never meant any harm to you
-
-    // Don't stop thinking about tomorrow
-    // Don't stop, it'll soon be here
-    // It'll be better than before
-    // Yesterday's gone, yesterday's gone
-    slow_wallet::filo_migration_reset(user_sig);
 
     // Good evening
     // You know my name
@@ -69,6 +66,18 @@ module ol_framework::filo_migration {
     // I'm still standing. Yeah, yeah, yeah
     // I'm still standing. Yeah, yeah, yeah
     page_rank_lazy::maybe_initialize_trust_record(user_sig);
+
+
+    // All I want is to see you smile
+    // If it takes just a little while
+    // I know you don't believe that it's true
+    // I never meant any harm to you
+
+    // Don't stop thinking about tomorrow
+    // Don't stop, it'll soon be here
+    // It'll be better than before
+    // Yesterday's gone, yesterday's gone
+    slow_wallet::filo_migration_reset(user_sig);
 
   }
   // FILO FTW

--- a/framework/libra-framework/sources/ol_sources/mock.move
+++ b/framework/libra-framework/sources/ol_sources/mock.move
@@ -579,7 +579,7 @@ public fun mock_vouch_score_50(framework: &signer, target_account: address): vec
 public fun simulate_v8_migration(sender: &signer) {
     // run migrations
     // Note, Activity and Founder struct should have been set above
-    filo_migration::maybe_migrate(sender);
+    filo_migration::test_unchecked_migration(sender);
     // touching the account will also increment activity
     activity::increment(sender);
 }


### PR DESCRIPTION
V8 Migration can be triggered twice. This is a nasty surprise if you had successfully gotten an account authorized and some coins unlocked. Most structs will be no-op when you try to migrate again. Except for Slow wallet, which will reset the balances back to zero. :(