### PR TITLE
Fix revokes per epoch counting

### DIFF
--- a/framework/libra-framework/sources/ol_sources/vouch_lib/vouch.move
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/vouch.move
@@ -375,11 +375,12 @@ module ol_framework::vouch {
 
       // lazy update counter
       if (current_epoch > lifetime.last_revocation_epoch) {
+        // If this is a new epoch vs the last revoke, reset the per-epoch count
         lifetime.last_revocation_epoch = current_epoch;
-      lifetime.revocations_this_epoch = lifetime.revocations_this_epoch + 1;
-
+        lifetime.revocations_this_epoch = 1;
       } else {
-        lifetime.revocations_this_epoch =1;
+        // Otherwise, increment the revoke count for the current epoch
+        lifetime.revocations_this_epoch = lifetime.revocations_this_epoch + 1;
       }
 
     }


### PR DESCRIPTION
The logic for maintaining the revocations_this_epoch count was incorrect: if the user sent two revoke txn in different epochs, the `revocations_this_epoch` counter would become wedged at 2. Then (I suspect) this would lead to the account becoming wedged in a state where it could perform no further revocations due to limit enforcement.