### PR TITLE
Make the two instances of MAX_PROCESSED_ADDRESSES have the same value

### DIFF
--- a/framework/libra-framework/sources/ol_sources/vouch_lib/distance_to_root.move
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/distance_to_root.move
@@ -7,7 +7,7 @@ module ol_framework::distance_to_root {
 
     // Constants
     const DEFAULT_INWARD_MAX_DEPTH: u64 = 10; // Maximum depth for inward path search
-    const MAX_PROCESSED_ADDRESSES: u64 = 1000; // Circuit breaker to prevent stack overflow
+    const MAX_PROCESSED_ADDRESSES: u64 = 10_000; // Circuit breaker to prevent stack overflow
     const SCORE_TTL_SECONDS: u64 = 1000; // Score validity period in seconds
 
     // Error codes

--- a/framework/libra-framework/sources/ol_sources/vouch_lib/page_rank.md
+++ b/framework/libra-framework/sources/ol_sources/vouch_lib/page_rank.md
@@ -52,7 +52,7 @@ Score depends on the paths from root nodes to the target node, with trust value 
 - Uses a transitive staleness propagation to ensure downstream accuracy.
 
 #### D. Circuit Breaker for Recursive Operations
-- Implemented a hard limit of 1000 processed addresses for any recursive operation.
+- Implemented a hard limit of 10000 processed addresses for any recursive operation.
 - Prevents stack overflows in complex trust networks or denial-of-service attacks.
 - Ensures predicable resource usage for mark-as-stale operations.
 


### PR DESCRIPTION
These limit constants are performing essentially the same function in two different parts of the codebase.
The actual value doesn't matter so much, since the goal is just to terminate execution before the runtime kills the process, but it's confusing to have two different values.